### PR TITLE
Make python plugins optional

### DIFF
--- a/Wox.Infrastructure/UserSettings/UserSetting.cs
+++ b/Wox.Infrastructure/UserSettings/UserSetting.cs
@@ -11,6 +11,12 @@ namespace Wox.Infrastructure.UserSettings
         public List<WebSearch> WebSearches { get; set; }
         public List<CustomPluginHotkey> CustomPluginHotkeys { get; set; }
         public bool StartWoxOnSystemStartup { get; set; }
+        public bool EnablePythonPlugins { get; set; }
+
+        public UserSetting()
+        {
+            EnablePythonPlugins = false;
+        }
 
         public List<WebSearch> LoadDefaultWebSearches()
         {

--- a/Wox/PluginLoader/Plugins.cs
+++ b/Wox/PluginLoader/Plugins.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using Microsoft.CSharp;
 using Wox.Helper;
+using Wox.Infrastructure;
 using Wox.Plugin;
 
 namespace Wox.PluginLoader
@@ -18,7 +19,11 @@ namespace Wox.PluginLoader
             plugins.Clear();
             BasePluginLoader.ParsePluginsConfig();
 
-            plugins.AddRange(new PythonPluginLoader().LoadPlugin());
+            if (CommonStorage.Instance.UserSetting.EnablePythonPlugins)
+            {
+                plugins.AddRange(new PythonPluginLoader().LoadPlugin());    
+            }
+
             plugins.AddRange(new CSharpPluginLoader().LoadPlugin());
             foreach (IPlugin plugin in plugins.Select(pluginPair => pluginPair.Plugin))
             {

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -23,9 +23,6 @@
                     <TextBlock Text="Theme:" />
                     <ComboBox x:Name="themeComboBox" SelectionChanged="ThemeComboBox_OnSelectionChanged" HorizontalAlignment="Left" VerticalAlignment="Top" Width="120"/>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="10">
-                    <Button x:Name="btnEnableInstaller" Click="BtnEnableInstaller_OnClick">enable plugin installer</Button>
-                </StackPanel>
             </StackPanel>
         </TabItem>
         <TabItem Header="Hotkey">
@@ -106,6 +103,17 @@
                     <Button x:Name="btnAddWebSearch" Click="btnAddWebSearch_OnClick" Width="100" Margin="10">Add</Button>
                 </StackPanel>
             </Grid>
+        </TabItem>
+        <TabItem Header="Plugins">
+            <StackPanel Orientation="Vertical" Margin="10">
+                <StackPanel Orientation="Horizontal" Margin="10">
+                    <CheckBox x:Name="cbEnablePythonPlugins" />
+                    <TextBlock Text="Enable Python Plugins" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="10">
+                    <Button x:Name="btnEnableInstaller" Click="BtnEnableInstaller_OnClick">enable plugin installer</Button>
+                </StackPanel>
+            </StackPanel>
         </TabItem>
     </TabControl>
 </Window>

--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -46,6 +46,17 @@ namespace Wox
                 CommonStorage.Instance.Save();
             };
 
+            cbEnablePythonPlugins.Checked += (o, e) =>
+            {
+                CommonStorage.Instance.UserSetting.EnablePythonPlugins = true;
+                CommonStorage.Instance.Save();
+            };
+            cbEnablePythonPlugins.Unchecked += (o, e) =>
+            {
+                CommonStorage.Instance.UserSetting.EnablePythonPlugins = false;
+                CommonStorage.Instance.Save();
+            };
+
 
             foreach (string theme in LoadAvailableThemes())
             {
@@ -57,6 +68,7 @@ namespace Wox
             cbReplaceWinR.IsChecked = CommonStorage.Instance.UserSetting.ReplaceWinR;
             webSearchView.ItemsSource = CommonStorage.Instance.UserSetting.WebSearches;
             lvCustomHotkey.ItemsSource = CommonStorage.Instance.UserSetting.CustomPluginHotkeys;
+            cbEnablePythonPlugins.IsChecked = CommonStorage.Instance.UserSetting.EnablePythonPlugins;
             cbStartWithWindows.IsChecked = File.Exists(woxLinkPath);
         }
 

--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -46,6 +46,7 @@ namespace Wox
                 CommonStorage.Instance.Save();
             };
 
+
             foreach (string theme in LoadAvailableThemes())
             {
                 string themeName = theme.Substring(theme.LastIndexOf('\\') + 1).Replace(".xaml", "");
@@ -118,6 +119,8 @@ namespace Wox
         private void CbStartWithWindows_OnChecked(object sender, RoutedEventArgs e)
         {
             CreateStartupFolderShortcut();
+            CommonStorage.Instance.UserSetting.StartWoxOnSystemStartup = true;
+            CommonStorage.Instance.Save();
         }
 
         private void CbStartWithWindows_OnUnchecked(object sender, RoutedEventArgs e)
@@ -126,6 +129,9 @@ namespace Wox
             {
                 File.Delete(woxLinkPath);
             }
+
+            CommonStorage.Instance.UserSetting.StartWoxOnSystemStartup = false;
+            CommonStorage.Instance.Save();
         }
 
         private void CreateStartupFolderShortcut()


### PR DESCRIPTION
Wox crashes on Windows 8 when trying to load the Python plugins, i can't pinpoint the exact error, it happens in the Python.Runtime project when calling `Runtime.Py_Initialize();` in `runtime.cs` [right here](https://github.com/Rovak/Wox/blob/python-optional/Pythonnet.Runtime/runtime.cs?pr=%2Fqianlifeng%2FWox%2Fpull%2F51#L78)

This is more of a workaround instead of an actual fix for the Python.Runtime error

Other changes:
- Save StartWoxOnSystemStartup when changing checkbox
- Add new tab Plugins
- Add new option to optionally load python plugin
