### PR TITLE
Opening Settings from tray and the ability to leave the windows command prompt open after running a command

### DIFF
--- a/Wox.Infrastructure/Storage/UserSettings/UserSettingStorage.cs
+++ b/Wox.Infrastructure/Storage/UserSettings/UserSettingStorage.cs
@@ -68,6 +68,9 @@ namespace Wox.Infrastructure.Storage.UserSettings
         [JsonProperty]
         public OpacityMode OpacityMode { get; set; }
 
+		[JsonProperty]
+		public bool LeaveCmdOpen { get; set; }
+
         public List<WebSearch> LoadDefaultWebSearches()
         {
             List<WebSearch> webSearches = new List<WebSearch>();
@@ -137,7 +140,8 @@ namespace Wox.Infrastructure.Storage.UserSettings
             QueryBoxFont = FontFamily.GenericSansSerif.Name;
             ResultItemFont = FontFamily.GenericSansSerif.Name;
             Opacity = 1;
-            OpacityMode = OpacityMode.Normal;
+	        OpacityMode = OpacityMode.Normal;
+	        LeaveCmdOpen = false;
         }
 
     }

--- a/Wox.Infrastructure/WindowsShellRun.cs
+++ b/Wox.Infrastructure/WindowsShellRun.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.IO;
+using Wox.Infrastructure.Storage.UserSettings;
 
 namespace Wox.Infrastructure
 {
@@ -102,7 +103,21 @@ namespace Wox.Infrastructure
                     startDir = dir;
             }
 
-            global::System.Diagnostics.ProcessStartInfo startInfo = new global::System.Diagnostics.ProcessStartInfo();
+	        if (UserSettingStorage.Instance.LeaveCmdOpen)
+	        {
+		        string cmdExe;
+		        string dummy;
+				EvaluateSystemAndUserCommandLine("cmd.exe", startDir, out cmdExe, out dummy, dwSeclFlags);
+
+				// check whether user typed >cmd, because we don't want to create 2 nested shells
+		        if (cmdExe != cmd)
+		        {
+			        args = string.Format("/k {0} {1}", cmd, args);
+			        cmd = cmdExe;
+		        }
+	        }
+
+	        global::System.Diagnostics.ProcessStartInfo startInfo = new global::System.Diagnostics.ProcessStartInfo();
             startInfo.UseShellExecute = true;
             startInfo.Arguments = args;
             startInfo.FileName = cmd;

--- a/Wox/MainWindow.xaml.cs
+++ b/Wox/MainWindow.xaml.cs
@@ -23,6 +23,7 @@ using Wox.Infrastructure.Storage;
 using Wox.Infrastructure.Storage.UserSettings;
 using Wox.Plugin;
 using Wox.PluginLoader;
+using Wox.Properties;
 using Application = System.Windows.Application;
 using Brushes = System.Windows.Media.Brushes;
 using Color = System.Windows.Media.Color;
@@ -179,9 +180,11 @@ namespace Wox
             notifyIcon.Click += (o, e) => ShowWox();
             var open = new MenuItem("Open");
             open.Click += (o, e) => ShowWox();
+	        var setting = new MenuItem("Setting");
+	        setting.Click += (o, e) => OpenSettingDialog();
             var exit = new MenuItem("Exit");
             exit.Click += (o, e) => CloseApp();
-            MenuItem[] childen = { open, exit };
+            MenuItem[] childen = { open, setting, exit };
             notifyIcon.ContextMenu = new ContextMenu(childen);
         }
 

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -29,6 +29,10 @@
                     <CheckBox x:Name="cbReplaceWinR" />
                     <TextBlock Text="Replace Win+R" />
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="10">
+                    <CheckBox x:Name="cbLeaveCmdOpen" />
+                    <TextBlock Text="Do not close Command Prompt after command execution" />
+                </StackPanel>
             </StackPanel>
         </TabItem>
         <TabItem Header="Features">

--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -76,6 +76,17 @@ namespace Wox
 				UserSettingStorage.Instance.Save();
 			};
 
+			cbLeaveCmdOpen.Checked += (o, e) => {
+				UserSettingStorage.Instance.LeaveCmdOpen = true;
+				UserSettingStorage.Instance.Save();
+			};
+
+			cbLeaveCmdOpen.Unchecked += (o, e) =>
+			{
+				UserSettingStorage.Instance.LeaveCmdOpen = false;
+				UserSettingStorage.Instance.Save();
+			};
+
             #region Load Theme Data
 
             if (!string.IsNullOrEmpty(UserSettingStorage.Instance.QueryBoxFont) &&
@@ -167,6 +178,7 @@ namespace Wox
             cbEnablePythonPlugins.IsChecked = UserSettingStorage.Instance.EnablePythonPlugins;
             cbStartWithWindows.IsChecked = File.Exists(woxLinkPath);
             cbEnableBookmarkPlugin.IsChecked = UserSettingStorage.Instance.EnableBookmarkPlugin;
+	        cbLeaveCmdOpen.IsChecked = UserSettingStorage.Instance.LeaveCmdOpen;
 
             var features = new CompositeCollection
             {


### PR DESCRIPTION
- added option to open Wox Settings from the tray menu
- added a checkbox option specifying whether to leave the command line open after having run a command like >ping google.com
