### PR TITLE
WindowOpener class

### DIFF
--- a/Wox/Helper/WindowOpener.cs
+++ b/Wox/Helper/WindowOpener.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+
+namespace Wox.Helper
+{
+	public static class WindowOpener
+	{
+		public static T Open<T>(params object[] args) where T : Window
+		{
+			var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.GetType() == typeof(T))
+						 ?? (T)Activator.CreateInstance(typeof(T), args);
+			window.Show();
+			window.Focus();
+			Application.Current.MainWindow.Hide();
+			
+			return (T)window;
+		}
+	}
+}

--- a/Wox/MainWindow.xaml.cs
+++ b/Wox/MainWindow.xaml.cs
@@ -517,7 +517,7 @@ namespace Wox
 
         public void OpenSettingDialog()
         {
-            new SettingWindow(this).Show();
+	        WindowOpener.Open<SettingWindow>(this);
         }
 
         public void ShowCurrentResultItemTooltip(string text)

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Helper\SyntaxSugars.cs" />
     <Compile Include="Helper\WallpaperPathRetrieval.cs" />
     <Compile Include="Helper\WindowIntelopHelper.cs" />
+    <Compile Include="Helper\WindowOpener.cs" />
     <Compile Include="OpacityModeConverter.cs" />
     <Compile Include="CustomPluginHotkeySetting.xaml.cs">
       <DependentUpon>CustomPluginHotkeySetting.xaml</DependentUpon>


### PR DESCRIPTION
Added WindowOpener class, which makes sure that there cannot be two or more windows of the same type opened simultaneously. Until now, this situation could only occur with SettingWindow. Changing values in one SettingWindow would not have updated the other, so things could have theoretically got a little confusing.
