### PR TITLE
Fix the problem of sleep command and change the behavior of executing command.

### DIFF
--- a/Wox.Infrastructure/WindowsShellRun.cs
+++ b/Wox.Infrastructure/WindowsShellRun.cs
@@ -297,6 +297,9 @@ namespace Wox.Infrastructure
             int driveId = -1;
             if (PromptForMedia(cmd, out driveId))
             {
+                string oldCwd = Environment.CurrentDirectory;
+                string home = Environment.GetEnvironmentVariable("HOME");
+                Environment.CurrentDirectory = home;
                 ShellExecCmdLine(
                     IntPtr.Zero,
                     errorDialogHwnd,
@@ -305,6 +308,7 @@ namespace Wox.Infrastructure
                     global::System.Diagnostics.ProcessWindowStyle.Normal,
                     ShellExecCmdLineFlags.SECL__IGNORE_ERROR | ShellExecCmdLineFlags.SECL_USE_IDLIST | ShellExecCmdLineFlags.SECL_LOG_USAGE | (showErrorDialog ? 0 : ShellExecCmdLineFlags.SECL_NO_UI)
                 );
+                Environment.CurrentDirectory = oldCwd;
             }
             else
             {   // Device not ready 0x80070015

--- a/Wox.Plugin.SystemPlugins/Sys.cs
+++ b/Wox.Plugin.SystemPlugins/Sys.cs
@@ -94,7 +94,7 @@ namespace Wox.Plugin.SystemPlugins
                 Action = (c) =>
                 {
                     ProcessStartInfo Info = new ProcessStartInfo();
-                    Info.Arguments = "/C sleep 1 && \"" + Application.ExecutablePath + "\"";
+                    Info.Arguments = "/C ping 127.0.0.1 -n 1 && \"" + Application.ExecutablePath + "\"";
                     Info.WindowStyle = ProcessWindowStyle.Hidden;
                     Info.CreateNoWindow = true;
                     Info.FileName = "cmd.exe";


### PR DESCRIPTION
1. Fix the problem of sleep command. Sorry for my mistake that didn't know Windows doesn't have sleep command.
2. Change current working directory to environment variable %HOME% before executing command. I think it is better to run cmd under HOME directory than the working directory of Wox.
