### PR TITLE
允许更多快捷键

### DIFF
--- a/Wox/HotkeyControl.xaml.cs
+++ b/Wox/HotkeyControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -63,18 +64,12 @@ namespace Wox
                 text += "Ctrl + Alt";
             }
 
-            if (IsKeyACharOrNumber(key))
-            {
-                text += " + " + key;
-            }
-            else if (key == Key.Space)
-            {
-                text += " + Space";
-            }
-            else
+            if (IsModifierKey(key))
             {
                 return;
             }
+
+            text += " + " + key;
 
             if (text == tbHotkey.Text)
             {
@@ -132,9 +127,10 @@ namespace Wox
 
         }
 
-        private static bool IsKeyACharOrNumber(Key key)
+        private static bool IsModifierKey(Key key)
         {
-            return (key >= Key.A && key <= Key.Z) || (key >= Key.D0 && key <= Key.D9);
+            return (key == Key.LeftAlt || key == Key.LeftCtrl || key == Key.LeftShift || key == Key.LWin ||
+                    key == Key.RightAlt || key == Key.RightCtrl || key == Key.RightShift || key == Key.RWin);
         }
     }
 }


### PR DESCRIPTION
发现快捷键只能是辅助键 + 字母，数字，空格。
不允许F1～F12觉得不合理，修改了判别方式。
