### PR TITLE
Display plugin icons

### DIFF
--- a/Plugins/Wox.Plugin.PluginManagement/Main.cs
+++ b/Plugins/Wox.Plugin.PluginManagement/Main.cs
@@ -209,7 +209,7 @@ namespace Wox.Plugin.PluginManagement
                 {
                     Title = plugin.Name,
                     SubTitle = plugin.Description,
-                    IcoPath = "Images\\plugin.png",
+                    IcoPath = plugin.FullIcoPath,
                     Action = e =>
                     {
                         UnInstalledPlugins(plugin);
@@ -239,7 +239,7 @@ namespace Wox.Plugin.PluginManagement
                 {
                     Title = plugin.Name + " - " + plugin.ActionKeyword,
                     SubTitle = plugin.Description,
-                    IcoPath = "Images\\plugin.png"
+                    IcoPath = plugin.FullIcoPath
                 });
             }
             return results;

--- a/Wox.Plugin.SystemPlugins/ThirdpartyPluginIndicator.cs
+++ b/Wox.Plugin.SystemPlugins/ThirdpartyPluginIndicator.cs
@@ -35,7 +35,7 @@ namespace Wox.Plugin.SystemPlugins
                         Title = metadata.ActionKeyword,
                         SubTitle = string.Format("Activate {0} plugin", metadata.Name),
                         Score = 100,
-                        IcoPath = "Images/work.png",
+                        IcoPath = metadata.FullIcoPath,
                         Action = (c) =>
                         {
                             context.API.ChangeQuery(metadataCopy.ActionKeyword + " ");

--- a/Wox.Plugin/PluginMetadata.cs
+++ b/Wox.Plugin/PluginMetadata.cs
@@ -52,7 +52,9 @@ namespace Wox.Plugin
         {
             get
             {
-                if (string.IsNullOrEmpty(IcoPath)) return string.Empty;
+                // Return the default icon if IcoPath is empty
+                if (string.IsNullOrEmpty(IcoPath))
+                    return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images\\work.png");
 
                 if (IcoPath.StartsWith("data:"))
                 {


### PR DESCRIPTION
Show plugin icons instead of the default icon
- in the `activate plugin` query, which closes #165 
- in the package manager's `wpm list` and `wpm uninstall` queries
