### PR TITLE
Fixed commit #334 multiple SelectionChanged firing

### DIFF
--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -167,6 +167,7 @@ namespace Wox
         private void settingTab_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             // Update controls inside the selected tab
+            if (e.OriginalSource != settingTab) return;
 
             if (tabPlugin.IsSelected)
             {


### PR DESCRIPTION
settingTab_SelectionChanged would get fired if an ItemsSource was updated in any childcontrol of the tab. 
Added a check that will verify that SelectionChanged was actually fired by TabControl
