### PR TITLE
Bugfix crash on restart

### DIFF
--- a/Plugins/Wox.Plugin.Sys/Sys.cs
+++ b/Plugins/Wox.Plugin.Sys/Sys.cs
@@ -119,7 +119,7 @@ namespace Wox.Plugin.Sys
 				    Action = (c) =>
 				    {
 				        ProcessStartInfo Info = new ProcessStartInfo();
-				        Info.Arguments = "/C ping 127.0.0.1 -n 1 && \"" + Application.ExecutablePath + "\"";
+				        Info.Arguments = "/C ping 127.0.0.1 -n 3 && \"" + Application.ExecutablePath + "\"";
 				        Info.WindowStyle = ProcessWindowStyle.Hidden;
 				        Info.CreateNoWindow = true;
 				        Info.FileName = "cmd.exe";


### PR DESCRIPTION
As said in issue #322, restart command causes Wox to crash completely. 
On both of my systems Wox takes more time to close than it takes to execute the `ping` command, because of that, instead of a new instance of Wox being launched, the previous process is called and Wox tries to act as if it is running. 

A bigger restart delay seems to fix this.
