### PR TITLE
Fixes restart bug in #322 

### DIFF
--- a/Plugins/Wox.Plugin.PluginManagement/Main.cs
+++ b/Plugins/Wox.Plugin.PluginManagement/Main.cs
@@ -241,7 +241,7 @@ namespace Wox.Plugin.PluginManagement
                     MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
                     ProcessStartInfo Info = new ProcessStartInfo();
-                    Info.Arguments = "/C ping 127.0.0.1 -n 1 && \"" + Application.ExecutablePath + "\"";
+                    Info.Arguments = "/C ping 127.0.0.1 -n 3 && \"" + Application.ExecutablePath + "\"";
                     Info.WindowStyle = ProcessWindowStyle.Hidden;
                     Info.CreateNoWindow = true;
                     Info.FileName = "cmd.exe";

--- a/Wox.Core/Plugin/PluginInstaller.cs
+++ b/Wox.Core/Plugin/PluginInstaller.cs
@@ -85,7 +85,7 @@ namespace Wox.Core.Plugin
                             MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                     {
                         ProcessStartInfo Info = new ProcessStartInfo();
-                        Info.Arguments = "/C ping 127.0.0.1 -n 1 && \"" +
+                        Info.Arguments = "/C ping 127.0.0.1 -n 3 && \"" +
                                          System.Windows.Forms.Application.ExecutablePath + "\"";
                         Info.WindowStyle = ProcessWindowStyle.Hidden;
                         Info.CreateNoWindow = true;


### PR DESCRIPTION
This is a repetition of #367 that covers the plugin manager too. 

> As said in issue #322, restart command causes Wox to crash completely. 
> On both of my systems Wox takes more time to close than it takes to execute the ping command, because of that, instead of a new instance of Wox being launched, the previous process is called and Wox tries to act as if it is running.
> 
> A bigger restart delay seems to fix this.
