### PR TITLE
Bugfix #271 positioning

### DIFF
--- a/Wox/Helper/WindowIntelopHelper.cs
+++ b/Wox/Helper/WindowIntelopHelper.cs
@@ -4,6 +4,8 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Interop;
+using System.Windows.Media;
+using Point = System.Windows.Point;
 
 namespace Wox.Helper
 {
@@ -79,6 +81,32 @@ namespace Wox.Helper
             var hwnd = new WindowInteropHelper(win).Handle;
             SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) & ~WS_SYSMENU);
         }
+
+        /// <summary>
+        /// Transforms pixels to Device Independent Pixels used by WPF
+        /// </summary>
+        /// <param name="visual">current window, required to get presentation source</param>
+        /// <param name="unitX">horizontal position in pixels</param>
+        /// <param name="unitY">vertical position in pixels</param>
+        /// <returns>point containing device independent pixels</returns>
+        public static Point TransformPixelsToDIP(Visual visual, double unitX, double unitY)
+        {
+            Matrix matrix;
+            var source = PresentationSource.FromVisual(visual);
+            if (source != null)
+            {
+                matrix = source.CompositionTarget.TransformFromDevice;
+            }
+            else
+            {
+                using (var src = new HwndSource(new HwndSourceParameters()))
+                {
+                    matrix = src.CompositionTarget.TransformFromDevice;
+                }
+            }
+            return new Point((int) (matrix.M11*unitX), (int) (matrix.M22*unitY));
+        }
+
 
         [StructLayout(LayoutKind.Sequential)]
         public struct RECT

--- a/Wox/MainWindow.xaml.cs
+++ b/Wox/MainWindow.xaml.cs
@@ -260,34 +260,21 @@ namespace Wox
 
         private double GetWindowsLeft()
         {
-            var screen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
-            if (UserSettingStorage.Instance.RememberLastLaunchLocation)
-            {
-                var origScreen = Screen.FromRectangle(new Rectangle((int)Left, (int)Top, (int)ActualWidth, (int)ActualHeight));
-                var coordX = (Left - origScreen.WorkingArea.Left) / (origScreen.WorkingArea.Width - ActualWidth);
-                UserSettingStorage.Instance.WindowLeft = (screen.WorkingArea.Width - ActualWidth) * coordX + screen.WorkingArea.Left;
-            }
-            else
-            {
-                UserSettingStorage.Instance.WindowLeft = (screen.WorkingArea.Width - ActualWidth) / 2 + screen.WorkingArea.Left;
-            }
+            if (UserSettingStorage.Instance.RememberLastLaunchLocation) return UserSettingStorage.Instance.WindowLeft;
 
+            var screen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
+            var dipPoint = WindowIntelopHelper.TransformPixelsToDIP(this, screen.WorkingArea.Width, 0);
+            UserSettingStorage.Instance.WindowLeft = (dipPoint.X - ActualWidth)/2;
             return UserSettingStorage.Instance.WindowLeft;
         }
 
         private double GetWindowsTop()
         {
+            if (UserSettingStorage.Instance.RememberLastLaunchLocation) return UserSettingStorage.Instance.WindowTop;
+
             var screen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
-            if (UserSettingStorage.Instance.RememberLastLaunchLocation)
-            {
-                var origScreen = Screen.FromRectangle(new Rectangle((int)Left, (int)Top, (int)ActualWidth, (int)ActualHeight));
-                var coordY = (Top - origScreen.WorkingArea.Top) / (origScreen.WorkingArea.Height - ActualHeight);
-                UserSettingStorage.Instance.WindowTop = (screen.WorkingArea.Height - ActualHeight) * coordY + screen.WorkingArea.Top;
-            }
-            else
-            {
-                UserSettingStorage.Instance.WindowTop = (screen.WorkingArea.Height - tbQuery.ActualHeight) / 4 + screen.WorkingArea.Top;
-            }
+            var dipPoint = WindowIntelopHelper.TransformPixelsToDIP(this, 0, screen.WorkingArea.Height);
+            UserSettingStorage.Instance.WindowTop = (dipPoint.Y - tbQuery.ActualHeight)/4;
             return UserSettingStorage.Instance.WindowTop;
         }
 
@@ -534,6 +521,8 @@ namespace Wox
 
         private void HideWox()
         {
+            UserSettingStorage.Instance.WindowLeft = Left;
+            UserSettingStorage.Instance.WindowTop = Top;
             if (IsInContextMenuMode)
             {
                 BackToResultMode();

--- a/Wox/Msg.xaml.cs
+++ b/Wox/Msg.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
+using Wox.Helper;
 
 namespace Wox {
 	public partial class Msg : Window {
@@ -13,15 +14,18 @@ namespace Wox {
 
 		public Msg() {
 			InitializeComponent();
-
-			Left = Screen.PrimaryScreen.WorkingArea.Right - this.Width;
-			Top = Screen.PrimaryScreen.Bounds.Bottom;
-			showAnimation.From = Screen.PrimaryScreen.Bounds.Bottom;
-			showAnimation.To = Screen.PrimaryScreen.WorkingArea.Bottom - Height;
+		    var screen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
+		    var dipWorkingArea = WindowIntelopHelper.TransformPixelsToDIP(this, 
+                screen.WorkingArea.Width,
+		        screen.WorkingArea.Height);
+			Left = dipWorkingArea.X - this.Width;
+		    Top = dipWorkingArea.Y;
+			showAnimation.From = dipWorkingArea.Y;
+			showAnimation.To = dipWorkingArea.Y - Height; 
 
 			// Create the fade out storyboard
 			fadeOutStoryboard.Completed += new EventHandler(fadeOutStoryboard_Completed);
-			DoubleAnimation fadeOutAnimation = new DoubleAnimation(Screen.PrimaryScreen.WorkingArea.Bottom - Height, Screen.PrimaryScreen.Bounds.Bottom, new Duration(TimeSpan.FromSeconds(0.3))) {
+			DoubleAnimation fadeOutAnimation = new DoubleAnimation(dipWorkingArea.Y - Height, dipWorkingArea.Y, new Duration(TimeSpan.FromSeconds(0.3))) {
 				AccelerationRatio = 0.2
 			};
 			Storyboard.SetTarget(fadeOutAnimation, this);


### PR DESCRIPTION
Concluded on a fix for #271. Initial idea was to use `Graphics` class to determine DPI and recalculate the correct position inside of Wox. Turns out, it was not necessary. `CompositionTarget` can do that for us. 
- GetWindowsLeft and GetWindowsTop now converts screen pixels to device independent pixels, which is what WPF uses everywhere. 
- Wox position updated in UserSettingStorage everytime the window hides. The config is saved as before - only when Wox **closes**. 
- Msg user control now also uses **DIP** instead of normal pixels. Msg notification now show up on high-dpi screens. 

Tested on a virtual machine with 125 and 150% scaling. Working as expected. I recommend gathering more test data inside of #271 before accepting the PR. 
