### PR TITLE
Bugfix for issue #397

### DIFF
--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -425,7 +425,12 @@ namespace Wox
             var wallpaper = WallpaperPathRetrieval.GetWallpaperPath();
             if (wallpaper != null && File.Exists(wallpaper))
             {
-                var brush = new ImageBrush(new BitmapImage(new Uri(wallpaper)));
+                var memStream = new MemoryStream(File.ReadAllBytes(wallpaper));
+                var bitmap = new BitmapImage();
+                bitmap.BeginInit();
+                bitmap.StreamSource = memStream;
+                bitmap.EndInit();
+                var brush = new ImageBrush(bitmap);
                 brush.Stretch = Stretch.UniformToFill;
                 PreviewPanel.Background = brush;
             }


### PR DESCRIPTION
Wallpaper is now cached in Wox's memory, so that the wallpaper file remains unlocked. 

Wallpapers tend to occupy around 500 kb, the GC disposes them so there is no memory leak. 
