### PR TITLE
Fix #447 Trailing slash for folders plugin

### DIFF
--- a/Plugins/Wox.Plugin.Folder/FolderPlugin.cs
+++ b/Plugins/Wox.Plugin.Folder/FolderPlugin.cs
@@ -109,7 +109,7 @@ namespace Wox.Plugin.Folder
                                     return false;
                                 }
                             }
-                            context.API.ChangeQuery(item.Path);
+                            context.API.ChangeQuery(item.Path+"\\");
                             return false;
                         },
                         ContextData = item

--- a/Plugins/Wox.Plugin.Folder/FolderPlugin.cs
+++ b/Plugins/Wox.Plugin.Folder/FolderPlugin.cs
@@ -109,7 +109,7 @@ namespace Wox.Plugin.Folder
                                     return false;
                                 }
                             }
-                            context.API.ChangeQuery(item.Path+"\\");
+                            context.API.ChangeQuery(item.Path + (item.Path.EndsWith("\\")? "": "\\"));
                             return false;
                         },
                         ContextData = item


### PR DESCRIPTION
Fix for issue #447, added a trailing slash upon selecting a saved folder
