### PR TITLE
fix typo

### DIFF
--- a/Plugins/Wox.Plugin.WebSearch/WebSearchStorage.cs
+++ b/Plugins/Wox.Plugin.WebSearch/WebSearchStorage.cs
@@ -26,7 +26,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Google",
                     ActionKeyword = "g",
                     IconPath = "Images\\google.png",
-                    Url = "https://www.google.com/search?q=new WebSearch {q}",
+                    Url = "https://www.google.com/search?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -34,7 +34,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Wikipedia",
                     ActionKeyword = "wiki",
                     IconPath = "Images\\wiki.png",
-                    Url = "http://en.wikipedia.org/wiki/new WebSearch {q}",
+                    Url = "http://en.wikipedia.org/wiki/{q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -42,7 +42,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "FindIcon",
                     ActionKeyword = "findicon",
                     IconPath = "Images\\pictures.png",
-                    Url = "http://findicons.com/search/new WebSearch {q}",
+                    Url = "http://findicons.com/search/{q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -50,7 +50,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Facebook",
                     ActionKeyword = "facebook",
                     IconPath = "Images\\facebook.png",
-                    Url = "http://www.facebook.com/search/?q=new WebSearch {q}",
+                    Url = "http://www.facebook.com/search/?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -58,7 +58,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Twitter",
                     ActionKeyword = "twitter",
                     IconPath = "Images\\twitter.png",
-                    Url = "http://twitter.com/search?q=new WebSearch {q}",
+                    Url = "http://twitter.com/search?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -66,7 +66,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Google Maps",
                     ActionKeyword = "maps",
                     IconPath = "Images\\google_maps.png",
-                    Url = "http://maps.google.com/maps?q=new WebSearch {q}",
+                    Url = "http://maps.google.com/maps?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -74,7 +74,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Google Translate",
                     ActionKeyword = "translate",
                     IconPath = "Images\\google_translate.png",
-                    Url = "http://translate.google.com/#auto|en|new WebSearch {q}",
+                    Url = "http://translate.google.com/#auto|en|{q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -82,7 +82,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Duckduckgo",
                     ActionKeyword = "duckduckgo",
                     IconPath = "Images\\duckduckgo.png",
-                    Url = "https://duckduckgo.com/?q=new WebSearch {q}",
+                    Url = "https://duckduckgo.com/?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -90,7 +90,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Github",
                     ActionKeyword = "github",
                     IconPath = "Images\\github.png",
-                    Url = "https://github.com/search?q=new WebSearch {q}",
+                    Url = "https://github.com/search?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -98,7 +98,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Github Gist",
                     ActionKeyword = "gist",
                     IconPath = "Images\\gist.png",
-                    Url = "https://gist.github.com/search?q=new WebSearch {q}",
+                    Url = "https://gist.github.com/search?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -106,7 +106,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Gmail",
                     ActionKeyword = "gmail",
                     IconPath = "Images\\gmail.png",
-                    Url = "https://mail.google.com/mail/ca/u/0/#apps/new WebSearch {q}",
+                    Url = "https://mail.google.com/mail/ca/u/0/#apps/{q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -114,7 +114,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Google Drive",
                     ActionKeyword = "drive",
                     IconPath = "Images\\google_drive.png",
-                    Url = "http://drive.google.com/?hl=en&tab=bo#search/new WebSearch {q}",
+                    Url = "http://drive.google.com/?hl=en&tab=bo#search/{q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -122,7 +122,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Wolframalpha",
                     ActionKeyword = "wolframalpha",
                     IconPath = "Images\\wolframalpha.png",
-                    Url = "http://www.wolframalpha.com/input/?i=new WebSearch {q}",
+                    Url = "http://www.wolframalpha.com/input/?i={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -130,7 +130,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Stackoverflow",
                     ActionKeyword = "stackoverflow",
                     IconPath = "Images\\stackoverflow.png",
-                    Url = "http://stackoverflow.com/search?q=new WebSearch {q}",
+                    Url = "http://stackoverflow.com/search?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -138,7 +138,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "I'm Feeling Lucky",
                     ActionKeyword = "lucky",
                     IconPath = "Images\\google.png",
-                    Url = "http://google.com/search?q=new WebSearch {q}&btnI=I",
+                    Url = "http://google.com/search?q={q}&btnI=I",
                     Enabled = true
                 },
                 new WebSearch
@@ -146,7 +146,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Google Image",
                     ActionKeyword = "image",
                     IconPath = "Images\\google.png",
-                    Url = "https://www.google.com/search?q=new WebSearch {q}&tbm=isch",
+                    Url = "https://www.google.com/search?q={q}&tbm=isch",
                     Enabled = true
                 },
                 new WebSearch
@@ -154,7 +154,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Youtube",
                     ActionKeyword = "youtube",
                     IconPath = "Images\\youtube.png",
-                    Url = "http://www.youtube.com/results?search_query=new WebSearch {q}",
+                    Url = "http://www.youtube.com/results?search_query={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -162,7 +162,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Bing",
                     ActionKeyword = "bing",
                     IconPath = "Images\\bing.png",
-                    Url = "https://www.bing.com/search?q=new WebSearch {q}",
+                    Url = "https://www.bing.com/search?q={q}",
                     Enabled = true
                 },
                 new WebSearch
@@ -170,7 +170,7 @@ namespace Wox.Plugin.WebSearch
                     Title = "Yahoo",
                     ActionKeyword = "yahoo",
                     IconPath = "Images\\yahoo.png",
-                    Url = "http://www.search.yahoo.com/search?p=new WebSearch {q}",
+                    Url = "http://www.search.yahoo.com/search?p={q}",
                     Enabled = true
                 }
             });


### PR DESCRIPTION
The latest build from master will cause WebSearch Plugin to prepend "new WebSearch" to what user typed.
