### PR TITLE
Fixes MainWindow.xaml preview

### DIFF
--- a/Wox/MainWindow.xaml
+++ b/Wox/MainWindow.xaml
@@ -18,7 +18,7 @@
         Style="{DynamicResource WindowStyle}"
         Icon="Images\app.png"
         AllowsTransparency="True"
-        Visibility="{Binding IsVisible,Converter={converters:VisibilityConverter}}"
+        Visibility="{Binding WindowVisibility}"
         PreviewKeyDown="Window_PreviewKeyDown" d:DataContext="{d:DesignInstance vm:MainViewModel, IsDesignTimeCreatable=True}">
     <Window.Resources>
         <DataTemplate DataType="{x:Type vm:ResultPanelViewModel}">

--- a/Wox/MainWindow.xaml.cs
+++ b/Wox/MainWindow.xaml.cs
@@ -31,7 +31,6 @@ namespace Wox
         public MainWindow()
         {
             InitializeComponent();
-            
             Closing += MainWindow_Closing;
         }
 
@@ -76,7 +75,7 @@ namespace Wox
                 }
                 else if(eve.PropertyName == "IsVisible")
                 {
-                    if (vm.IsVisible)
+                    if (vm.WindowVisibility == System.Windows.Visibility.Visible)
                     {
                         this.tbQuery.Focus();
                     }

--- a/Wox/PublicAPIInstance.cs
+++ b/Wox/PublicAPIInstance.cs
@@ -202,13 +202,13 @@ namespace Wox
         {
             UserSettingStorage.Instance.WindowLeft = this.MainVM.Left;
             UserSettingStorage.Instance.WindowTop = this.MainVM.Top;
-            this.MainVM.IsVisible = false;
+            this.MainVM.WindowVisibility = Visibility.Hidden;
         }
 
         private void ShowWox(bool selectAll = true)
         {
             UserSettingStorage.Instance.IncreaseActivateTimes();
-            this.MainVM.IsVisible = true;
+            this.MainVM.WindowVisibility = Visibility.Visible;
             this.MainVM.SelectAllText = true;
         }
 
@@ -278,7 +278,7 @@ namespace Wox
 
         private void ToggleWox()
         {
-            if (!MainVM.IsVisible)
+            if (MainVM.WindowVisibility == Visibility.Hidden)
             {
                 ShowWox();
             }

--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -24,7 +24,7 @@ namespace Wox.ViewModel
         private ResultPanelViewModel _searchResultPanel;
         private ResultPanelViewModel _actionPanel;
         private string _queryText;
-        private bool _isVisible;
+
         private bool _isSearchResultPanelVisible;
         private bool _isActionPanelVisible;
         private bool _isProgressBarVisible;
@@ -33,6 +33,8 @@ namespace Wox.ViewModel
         private int _caretIndex;
         private double _left;
         private double _top;
+
+        private Visibility _windowVisibility;
 
         private bool _queryHasReturn;
         private Query _lastQuery = new Query();
@@ -114,24 +116,6 @@ namespace Wox.ViewModel
             }
         }
 
-        public bool IsVisible
-        {
-            get
-            {
-                return this._isVisible;
-            }
-            set
-            {
-                this._isVisible = value;
-                OnPropertyChanged("IsVisible");
-
-                if (!value && this.IsActionPanelVisible)
-                {
-                    this.BackToSearchMode();
-                }
-            }
-        }
-
         public bool IsSearchResultPanelVisible
         {
             get
@@ -207,6 +191,24 @@ namespace Wox.ViewModel
             {
                 this._top = value;
                 OnPropertyChanged("Top");
+            }
+        }
+
+        public Visibility WindowVisibility
+        {
+            get
+            {
+                return this._windowVisibility;
+            }
+            set
+            {
+                this._windowVisibility = value;
+                OnPropertyChanged("WindowVisibility");
+
+                if (value == Visibility.Hidden && this.IsActionPanelVisible)
+                {
+                    this.BackToSearchMode();
+                }
             }
         }
 
@@ -297,7 +299,7 @@ namespace Wox.ViewModel
                 }
                 else
                 {
-                    this.IsVisible = false;
+                    this.WindowVisibility = Visibility.Hidden;
                 }
 
             });


### PR DESCRIPTION
I went through the same problem this week on a project at work =x

We solve by changing the visibility property binding from bool to System.Window.Visibility, this way the preview was not supressed anymore =D
