### PR TITLE
Cleanup proxy enable/disable

### DIFF
--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -250,7 +250,7 @@
                 <CheckBox x:Name="cbEnableProxy" Margin="10">
                     <TextBlock Text="{DynamicResource enableProxy}"></TextBlock>
                 </CheckBox>
-                <Grid Margin="10">
+                <Grid Margin="10" IsEnabled="{Binding IsChecked, ElementName=cbEnableProxy}">
                     <Grid.RowDefinitions>
                         <RowDefinition ></RowDefinition>
                         <RowDefinition ></RowDefinition>
@@ -286,7 +286,7 @@
                         <PasswordBox Width="200" HorizontalAlignment="Left" x:Name="tbProxyPassword" />
                     </Border>
                 </Grid>
-                <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation="Horizontal" IsEnabled="{Binding IsChecked, ElementName=cbEnableProxy}">
                     <Button x:Name="btnTestProxy" Width="80" HorizontalAlignment="Left" Margin="10" Click="btnTestProxy_Click" Content="{DynamicResource testProxy}"></Button>
                     <Button x:Name="btnSaveProxy" Width="80" HorizontalAlignment="Left" Margin="10" Click="btnSaveProxy_Click" Content="{DynamicResource save}"></Button>
                 </StackPanel>

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -247,7 +247,7 @@
         </TabItem>
         <TabItem Header="{DynamicResource proxy}">
             <StackPanel>
-                <CheckBox x:Name="cbEnableProxy" Margin="10">
+                <CheckBox x:Name="cbEnableProxy" Margin="10" Checked="cbEnableProxy_Change" Unchecked="cbEnableProxy_Change">
                     <TextBlock Text="{DynamicResource enableProxy}"></TextBlock>
                 </CheckBox>
                 <Grid Margin="10" IsEnabled="{Binding IsChecked, ElementName=cbEnableProxy}">

--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -41,6 +41,12 @@ namespace Wox
             Loaded += Setting_Loaded;
         }
 
+        private void cbEnableProxy_Change(object sender, RoutedEventArgs e)
+        {
+            UserSettingStorage.Instance.ProxyEnabled = cbEnableProxy.IsChecked ?? false;
+            UserSettingStorage.Instance.Save();
+        }
+
         private void Setting_Loaded(object sender, RoutedEventArgs ev)
         {
             #region General

--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -116,8 +116,6 @@ namespace Wox
 
             #region Proxy
 
-            cbEnableProxy.Checked += (o, e) => EnableProxy();
-            cbEnableProxy.Unchecked += (o, e) => DisableProxy();
             cbEnableProxy.IsChecked = UserSettingStorage.Instance.ProxyEnabled;
             tbProxyServer.Text = UserSettingStorage.Instance.ProxyServer;
             if (UserSettingStorage.Instance.ProxyPort != 0)
@@ -126,14 +124,6 @@ namespace Wox
             }
             tbProxyUserName.Text = UserSettingStorage.Instance.ProxyUserName;
             tbProxyPassword.Password = UserSettingStorage.Instance.ProxyPassword;
-            if (UserSettingStorage.Instance.ProxyEnabled)
-            {
-                EnableProxy();
-            }
-            else
-            {
-                DisableProxy();
-            }
 
             #endregion
 
@@ -794,22 +784,6 @@ namespace Wox
             {
                 MessageBox.Show(InternationalizationManager.Instance.GetTranslation("proxyConnectFailed"));
             }
-        }
-
-        private void EnableProxy()
-        {
-            tbProxyPassword.IsEnabled = true;
-            tbProxyServer.IsEnabled = true;
-            tbProxyUserName.IsEnabled = true;
-            tbProxyPort.IsEnabled = true;
-        }
-
-        private void DisableProxy()
-        {
-            tbProxyPassword.IsEnabled = false;
-            tbProxyServer.IsEnabled = false;
-            tbProxyUserName.IsEnabled = false;
-            tbProxyPort.IsEnabled = false;
         }
 
         #endregion


### PR DESCRIPTION
This change causes the proxy _Test_ and _Save_ buttons to also be disabled (as well as the textboxes) when the proxy is not enabled and toggles this functionality in xaml rather than c#.
