### PR TITLE
Fix(Tray Menu): Can not load string from translated resource.

### DIFF
--- a/Wox.Core/Resource/Internationalization.cs
+++ b/Wox.Core/Resource/Internationalization.cs
@@ -12,7 +12,18 @@ namespace Wox.Core.Resource
 {
     public class Internationalization : Resource
     {
-        public UserSettingStorage Settings { get; set; }
+
+        private UserSettingStorage mSettings;
+
+        public UserSettingStorage Settings {
+            get {
+                return mSettings;
+            }
+            set {
+                mSettings = value;
+                ChangeLanguage(mSettings.Language); 
+            }
+        }
 
         public Internationalization()
         {


### PR DESCRIPTION
Fix(Tray Menu): Can not load string from translated resource.
