### PR TITLE
move disabled plugins to the bottom of the list

### DIFF
--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -744,14 +744,22 @@ namespace Wox
 
         private void OnPluginTabSelected()
         {
-            var plugins = new CompositeCollection
+            var plugins = PluginManager.AllPlugins;
+            //move all disabled to bottom
+            plugins.Sort(delegate (PluginPair a, PluginPair b)
+            {
+                int res = _settings.PluginSettings.Plugins[a.Metadata.ID].Disabled ? 1 : 0;
+                res += _settings.PluginSettings.Plugins[b.Metadata.ID].Disabled ? -1 : 0;
+                return res;
+            });
+
+            PluginsListBox.ItemsSource = new CompositeCollection
             {
                 new CollectionContainer
                 {
-                    Collection = PluginManager.AllPlugins
+                    Collection = plugins
                 }
-            };
-            PluginsListBox.ItemsSource = plugins;
+            }; ;
             PluginsListBox.SelectedIndex = 0;
         }
 


### PR DESCRIPTION
将设置界面中插件列表里的禁用插件移至列表最下方。

为了在列表里能够比较直观的体现插件禁用与否，本来还想加上禁用插件变灰（参考火狐里禁用的扩展组件），但是似乎WPF里没法很容易地把彩色图片变灰，所以暂时没做。
