### PR TITLE
Add ability to configure Everything executable working directory

### DIFF
--- a/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml
+++ b/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Wox.Plugin.Everything.EverythingSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             Loaded="View_Loaded"
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Border BorderBrush="Gray" Margin="10" BorderThickness="1">
+        <StackPanel>
+            <CheckBox x:Name="UseLocationAsWorkingDir" Content="{DynamicResource wox_plugin_everything_use_location_as_working_dir}" Margin="10" HorizontalAlignment="Left" />
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml.cs
+++ b/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace Wox.Plugin.Everything
+{
+    public partial class EverythingSettings : UserControl
+    {
+        private readonly Settings _settings;
+
+        public EverythingSettings(Settings settings)
+        {
+            InitializeComponent();
+            _settings = settings;
+        }
+
+        private void View_Loaded(object sender, RoutedEventArgs re)
+        {
+            UseLocationAsWorkingDir.IsChecked = _settings.UseLocationAsWorkingDir;
+
+            UseLocationAsWorkingDir.Checked += (o, e) =>
+            {
+                _settings.UseLocationAsWorkingDir = true;
+            };
+
+            UseLocationAsWorkingDir.Unchecked += (o, e) =>
+            {
+                _settings.UseLocationAsWorkingDir = false;
+            };
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.Everything/Languages/de.xaml
+++ b/Plugins/Wox.Plugin.Everything/Languages/de.xaml
@@ -11,4 +11,6 @@
     <system:String x:Key="wox_plugin_everything_plugin_name">Everything</system:String>
     <system:String x:Key="wox_plugin_everything_plugin_description">Suche Dateien mit Everything</system:String>
 
+    <system:String x:Key="wox_plugin_everything_use_location_as_working_dir">Verwenden Suchergebnis Standort als ausführbare Arbeitsverzeichnis</system:String>
+
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Everything/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Everything/Languages/en.xaml
@@ -11,4 +11,6 @@
     <system:String x:Key="wox_plugin_everything_plugin_name">Everything</system:String>
     <system:String x:Key="wox_plugin_everything_plugin_description">Search on-disk files using Everything</system:String>
 
+    <system:String x:Key="wox_plugin_everything_use_location_as_working_dir">Use search result's location as executable working directory</system:String>
+
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Everything/Languages/zh-cn.xaml
+++ b/Plugins/Wox.Plugin.Everything/Languages/zh-cn.xaml
@@ -10,5 +10,6 @@
 
     <system:String x:Key="wox_plugin_everything_plugin_name">Everything</system:String>
     <system:String x:Key="wox_plugin_everything_plugin_description">利用Everything搜索磁盘文件</system:String>
-    
+
+    <system:String x:Key="wox_plugin_everything_use_location_as_working_dir">使用搜索结果中的位置为可执行的工作目录</system:String>
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Everything/Languages/zh-tw.xaml
+++ b/Plugins/Wox.Plugin.Everything/Languages/zh-tw.xaml
@@ -10,4 +10,6 @@
 
     <system:String x:Key="wox_plugin_everything_plugin_name">Everything</system:String>
     <system:String x:Key="wox_plugin_everything_plugin_description">利用Everything搜索磁盤文件</system:String>
+
+    <system:String x:Key="wox_plugin_everything_use_location_as_working_dir">使用搜索結果中的位置為可執行的工作目錄</system:String>
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Everything/Main.cs
+++ b/Plugins/Wox.Plugin.Everything/Main.cs
@@ -6,13 +6,14 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Controls;
 using Wox.Infrastructure;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin.Everything.Everything;
 
 namespace Wox.Plugin.Everything
 {
-    public class Main : IPlugin, IPluginI18n, IContextMenu, ISavable
+    public class Main : IPlugin, ISettingProvider, IPluginI18n, IContextMenu, ISavable
     {
         private readonly EverythingAPI _api = new EverythingAPI();
 
@@ -45,6 +46,11 @@ namespace Wox.Plugin.Everything
                     foreach (var s in searchList)
                     {
                         var path = s.FullPath;
+
+                        string workingDir = null;
+                        if (_settings.UseLocationAsWorkingDir)
+                            workingDir = Path.GetDirectoryName(path);
+
                         Result r = new Result();
                         r.Title = Path.GetFileName(path);
                         r.SubTitle = path;
@@ -57,7 +63,8 @@ namespace Wox.Plugin.Everything
                                 Process.Start(new ProcessStartInfo
                                 {
                                     FileName = path,
-                                    UseShellExecute = true
+                                    UseShellExecute = true,
+                                    WorkingDirectory = workingDir
                                 });
                                 hide = true;
                             }
@@ -191,6 +198,11 @@ namespace Wox.Plugin.Everything
             }
 
             return contextMenus;
+        }
+
+        public Control CreateSettingPanel()
+        {
+            return new EverythingSettings(_settings);
         }
     }
 }

--- a/Plugins/Wox.Plugin.Everything/Settings.cs
+++ b/Plugins/Wox.Plugin.Everything/Settings.cs
@@ -10,6 +10,8 @@ namespace Wox.Plugin.Everything
         public List<ContextMenu> ContextMenus = new List<ContextMenu>();
 
         public int MaxSearchCount { get; set; } = 100;
+
+        public bool UseLocationAsWorkingDir { get; set; } = false;
     }
 
     public class ContextMenu

--- a/Plugins/Wox.Plugin.Everything/Wox.Plugin.Everything.csproj
+++ b/Plugins/Wox.Plugin.Everything/Wox.Plugin.Everything.csproj
@@ -51,10 +51,15 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SolutionAssemblyInfo.cs">
       <Link>Properties\SolutionAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="EverythingSettings.xaml.cs">
+      <DependentUpon>EverythingSettings.xaml</DependentUpon>
     </Compile>
     <Compile Include="Everything\Exceptions\CreateThreadException.cs" />
     <Compile Include="Everything\Exceptions\CreateWindowException.cs" />
@@ -139,6 +144,12 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="EverythingSettings.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Some apps or processes require to be run within a certain working directory. The current version of the Everything plugin does not set the working directory in `ProcessStartInfo` during a `Process.Start`. 

I have added the ability to configure the Everything plugin to use the search result's location as the working directory for the executed process.

Sorry for the multiple closed pull requests - I've selected the wrong source branches by mistake before.
