### PR TITLE
Improved English translations

### DIFF
--- a/Plugins/Wox.Plugin.Caculator/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Caculator/Languages/en.xaml
@@ -3,6 +3,6 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="wox_plugin_caculator_plugin_name">Calculator</system:String>
-    <system:String x:Key="wox_plugin_caculator_plugin_description">Provide mathematical calculations.(Try 5*3-2 in Wox)</system:String>
+    <system:String x:Key="wox_plugin_caculator_plugin_description">Allows to do mathematical calculations.(Try 5*3-2 in Wox)</system:String>
     
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Color/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Color/Languages/en.xaml
@@ -3,6 +3,6 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="wox_plugin_color_plugin_name">Colors</system:String>
-    <system:String x:Key="wox_plugin_color_plugin_description">Provide hex color preview.(Try #000 in Wox)</system:String>
+    <system:String x:Key="wox_plugin_color_plugin_description">Allows to preview colors using hex values.(Try #000 in Wox)</system:String>
     
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Everything/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Everything/Languages/en.xaml
@@ -3,7 +3,7 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="wox_plugin_everything_is_not_running">Everything is not running</system:String>
-    <system:String x:Key="wox_plugin_everything_query_error">Error querying Everything</system:String>
+    <system:String x:Key="wox_plugin_everything_query_error">Error while querying Everything</system:String>
     <system:String x:Key="wox_plugin_everything_copied">Copied</system:String>
     <system:String x:Key="wox_plugin_everything_canot_start">Can’t start {0}</system:String>
     <system:String x:Key="wox_plugin_everything_open_containing_folder">Open parent folder</system:String>

--- a/Plugins/Wox.Plugin.Folder/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Folder/Languages/en.xaml
@@ -7,9 +7,9 @@
     <system:String x:Key="wox_plugin_folder_add">Add</system:String>
     <system:String x:Key="wox_plugin_folder_folder_path">Folder Path</system:String>
     <system:String x:Key="wox_plugin_folder_select_folder_link_warning">Please select a folder link</system:String>
-    <system:String x:Key="wox_plugin_folder_delete_folder_link">Are your sure to delete {0}?</system:String>
+    <system:String x:Key="wox_plugin_folder_delete_folder_link">Are you sure you want to delete {0}?</system:String>
 
     <system:String x:Key="wox_plugin_folder_plugin_name">Folder</system:String>
-    <system:String x:Key="wox_plugin_folder_plugin_description">Open favorite folder from wox directly</system:String>
+    <system:String x:Key="wox_plugin_folder_plugin_description">Open favorite folder from Wox directly</system:String>
 
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.PluginIndicator/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.PluginIndicator/Languages/en.xaml
@@ -3,6 +3,6 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="wox_plugin_pluginindicator_plugin_name">Plugin Indicator</system:String>
-    <system:String x:Key="wox_plugin_pluginindicator_plugin_description">Provide plugin actionword suggestion</system:String>
+    <system:String x:Key="wox_plugin_pluginindicator_plugin_description">Provides plugins action words suggestions</system:String>
     
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.PluginManagement/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.PluginManagement/Languages/en.xaml
@@ -3,6 +3,6 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="wox_plugin_plugin_management_plugin_name">Wox Plugin Management</system:String>
-    <system:String x:Key="wox_plugin_plugin_management_plugin_description">Install/Remove/Update wox plugins</system:String>
+    <system:String x:Key="wox_plugin_plugin_management_plugin_description">Install, remove or update Wox plugins</system:String>
     
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Program/Languages/en.xaml
@@ -21,12 +21,12 @@
     <system:String x:Key="wox_plugin_program_max_search_depth">Maximum Search Depth (-1 is unlimited):</system:String>
 
     <system:String x:Key="wox_plugin_program_pls_select_program_source">Please select a program source</system:String>
-    <system:String x:Key="wox_plugin_program_delete_program_source">Are your sure to delete {0}?</system:String>
+    <system:String x:Key="wox_plugin_program_delete_program_source">Are you sure you want to delete {0}?</system:String>
 
     <system:String x:Key="wox_plugin_program_update">Update</system:String>
-    <system:String x:Key="wox_plugin_program_only_index_tip">Wox will only index files that end with following suffixes:</system:String>
+    <system:String x:Key="wox_plugin_program_only_index_tip">Wox will only index files that end with the following suffixes:</system:String>
     <system:String x:Key="wox_plugin_program_split_by_tip">(Each suffix should split by ;)</system:String>
-    <system:String x:Key="wox_plugin_program_update_file_suffixes">Sucessfully update file suffixes</system:String>
+    <system:String x:Key="wox_plugin_program_update_file_suffixes">Successfully updated file suffixes</system:String>
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">File suffixes can't be empty</system:String>
 
     <system:String x:Key="wox_plugin_program_run_as_administrator">Run As Administrator</system:String>

--- a/Plugins/Wox.Plugin.Shell/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Shell/Languages/en.xaml
@@ -5,7 +5,7 @@
     <system:String x:Key="wox_plugin_cmd_relace_winr">Replace Win+R</system:String>
     <system:String x:Key="wox_plugin_cmd_leave_cmd_open">Do not close Command Prompt after command execution</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_name">Shell</system:String>
-    <system:String x:Key="wox_plugin_cmd_plugin_description">Provide executing commands from Wox. Commands should start with ></system:String>
+    <system:String x:Key="wox_plugin_cmd_plugin_description">Allows to execute system commands from Wox. Commands should start with ></system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">this command has been executed {0} times</system:String>
     <system:String x:Key="wox_plugin_cmd_execute_through_shell">execute command through command shell</system:String>
     <system:String x:Key="wox_plugin_cmd_run_as_administrator">Run As Administrator</system:String>

--- a/Plugins/Wox.Plugin.WebSearch/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.WebSearch/Languages/en.xaml
@@ -22,10 +22,10 @@
     <system:String x:Key="wox_plugin_websearch_input_title">Please enter a title</system:String>
     <system:String x:Key="wox_plugin_websearch_input_action_keyword">Please enter an action keyword</system:String>
     <system:String x:Key="wox_plugin_websearch_input_url">Please enter a URL</system:String>
-    <system:String x:Key="wox_plugin_websearch_action_keyword_exist">ActionKeyword exists, please enter a different one</system:String>
+    <system:String x:Key="wox_plugin_websearch_action_keyword_exist">Action keyword already exists, please enter a different one</system:String>
     <system:String x:Key="wox_plugin_websearch_succeed">Success</system:String>
 
     <system:String x:Key="wox_plugin_websearch_plugin_name">Web Searches</system:String>
-    <system:String x:Key="wox_plugin_websearch_plugin_description">Provides web search ability</system:String>
+    <system:String x:Key="wox_plugin_websearch_plugin_description">Allows to perform web searches</system:String>
 
 </ResourceDictionary>

--- a/Wox/Languages/en.xaml
+++ b/Wox/Languages/en.xaml
@@ -18,7 +18,7 @@
     <system:String x:Key="wox_settings">Wox Settings</system:String>
     <system:String x:Key="general">General</system:String>
     <system:String x:Key="startWoxOnSystemStartup">Start Wox on system startup</system:String>
-    <system:String x:Key="hideWoxWhenLoseFocus">Hide Wox when focus lost</system:String>
+    <system:String x:Key="hideWoxWhenLoseFocus">Hide Wox when focus is lost</system:String>
     <system:String x:Key="dontPromptUpdateMsg">Do not show new version notifications</system:String>
     <system:String x:Key="rememberLastLocation">Remember last launch location</system:String>
     <system:String x:Key="language">Language</system:String>
@@ -56,7 +56,7 @@
     <system:String x:Key="edit">Edit</system:String>
     <system:String x:Key="add">Add</system:String>
     <system:String x:Key="pleaseSelectAnItem">Please select an item</system:String>
-    <system:String x:Key="deleteCustomHotkeyWarning">Are your sure to delete {0} plugin hotkey?</system:String>
+    <system:String x:Key="deleteCustomHotkeyWarning">Are you sure you want to delete {0} plugin hotkey?</system:String>
 
     <!--Setting Proxy-->
     <system:String x:Key="proxy">Proxy</system:String>
@@ -67,8 +67,8 @@
     <system:String x:Key="password">Password</system:String>
     <system:String x:Key="testProxy">Test Proxy</system:String>
     <system:String x:Key="save">Save</system:String>
-    <system:String x:Key="serverCantBeEmpty">Server can't be empty</system:String>
-    <system:String x:Key="portCantBeEmpty">Port can't be empty</system:String>
+    <system:String x:Key="serverCantBeEmpty">Server field can't be empty</system:String>
+    <system:String x:Key="portCantBeEmpty">Port field can't be empty</system:String>
     <system:String x:Key="invalidPortFormat">Invalid port format</system:String>
     <system:String x:Key="saveProxySuccessfully">Proxy saved successfully</system:String>
     <system:String x:Key="proxyIsCorrect">Proxy configured correctly</system:String>
@@ -78,9 +78,9 @@
     <system:String x:Key="about">About</system:String>
     <system:String x:Key="website">Website</system:String>
     <system:String x:Key="version">Version</system:String>
-    <system:String x:Key="about_activate_times">You have activated Wox for {0} times</system:String>
+    <system:String x:Key="about_activate_times">You have activated Wox {0} times</system:String>
     <system:String x:Key="checkUpdates">Check for Updates</system:String>
-    <system:String x:Key="newVersionTips">New version {0} avaiable, please restart wox</system:String>
+    <system:String x:Key="newVersionTips">New version {0} is available, please restart Wox</system:String>
     <system:String x:Key="releaseNotes">Release Notes:</system:String>
 
     <!--Action Keyword Setting Dialog-->
@@ -90,9 +90,9 @@
     <system:String x:Key="done">Done</system:String>
     <system:String x:Key="cannotFindSpecifiedPlugin">Can't find specified plugin</system:String>
     <system:String x:Key="newActionKeywordsCannotBeEmpty">New Action Keyword can't be empty</system:String>
-    <system:String x:Key="newActionKeywordsHasBeenAssigned">New ActionKeywords has been assigned to other plugin, please assign another new action keyword</system:String>
+    <system:String x:Key="newActionKeywordsHasBeenAssigned">New Action Keywords have been assigned to another plugin, please assign other new action keyword</system:String>
     <system:String x:Key="succeed">Succeed</system:String>
-    <system:String x:Key="actionkeyword_tips">Use * if you don't want to specify a action keyword</system:String>
+    <system:String x:Key="actionkeyword_tips">Use * if you don't want to specify an action keyword</system:String>
 
     <!--Custom Query Hotkey Dialog-->
     <system:String x:Key="preview">Preview</system:String>
@@ -120,7 +120,7 @@
     <system:String x:Key="reportWindow_wox_got_an_error">Wox got an error</system:String>
 
     <!--update-->
-    <system:String x:Key="update_wox_update_new_version_available">New Wox release {0} now available</system:String>
+    <system:String x:Key="update_wox_update_new_version_available">New Wox release {0} is now available</system:String>
     <system:String x:Key="update_wox_update_error">An error occurred while trying to install software updates</system:String>
     <system:String x:Key="update_wox_update">Update</system:String>
     <system:String x:Key="update_wox_update_cancel">Cancel</system:String>


### PR DESCRIPTION
I've went through lang files and improved some English translations.

Btw, I don't know if you are aware of this but calculator plugin folder has typo: "Caculator" (missing 'l')
