### PR TITLE
Fixed hide on startup problem

### DIFF
--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -60,10 +60,7 @@ namespace Wox
                 AutoStartup();
                 AutoUpdates();
 
-                if (!_settings.HideOnStartup)
-                {
-                    mainVM.MainWindowVisibility = Visibility.Visible;
-                }
+                mainVM.MainWindowVisibility = _settings.HideOnStartup ? Visibility.Hidden : Visibility.Visible;
             });
         }
 
@@ -102,7 +99,7 @@ namespace Wox
         }
 
         /// <summary>
-        /// let exception throw as normal is better for Debug 
+        /// let exception throw as normal is better for Debug
         /// </summary>
         [Conditional("RELEASE")]
         private void RegisterDispatcherUnhandledException()
@@ -113,7 +110,7 @@ namespace Wox
 
 
         /// <summary>
-        /// let exception throw as normal is better for Debug 
+        /// let exception throw as normal is better for Debug
         /// </summary>
         [Conditional("RELEASE")]
         private static void RegisterAppDomainExceptions()

--- a/Wox/MainWindow.xaml
+++ b/Wox/MainWindow.xaml
@@ -17,6 +17,7 @@
         Icon="Images\app.png"
         AllowsTransparency="True"
         Loaded="OnLoaded"
+        Initialized="OnInitialized"
         Closing="OnClosing"
         Drop="OnDrop"
         SizeChanged="OnSizeChanged"

--- a/Wox/MainWindow.xaml.cs
+++ b/Wox/MainWindow.xaml.cs
@@ -46,11 +46,15 @@ namespace Wox
             _viewModel.Save();
         }
 
+        private void OnInitialized(object sender, EventArgs e)
+        {
+            InitializeNotifyIcon();
+        }
+
         private void OnLoaded(object sender, RoutedEventArgs _)
         {
             WindowIntelopHelper.DisableControlBox(this);
             ThemeManager.Instance.ChangeTheme(_settings.Theme);
-            InitializeNotifyIcon();
             InitProgressbarAnimation();
 
             _viewModel.PropertyChanged += (o, e) =>
@@ -232,5 +236,5 @@ namespace Wox
         {
             QueryTextBox.CaretIndex = QueryTextBox.Text.Length;
         }
-    }
+  }
 }


### PR DESCRIPTION
Fixes bug which happens at least on Windows 10 where Wox is not hidden on startup when "Hide Wox on startup" is selected. It broke the tray icon so I fixed that too.
