### PR TITLE
Fixed issue where you can't edit a SearchSource

### DIFF
--- a/Plugins/Wox.Plugin.WebSearch/SearchSourceSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.WebSearch/SearchSourceSetting.xaml.cs
@@ -97,10 +97,10 @@ namespace Wox.Plugin.WebSearch
         private void EditSearchSource()
         {
             var keyword = _searchSource.ActionKeyword;
-            if (!PluginManager.ActionKeywordRegistered(keyword))
+            var newKeyword = keyword;
+            var oldKeyword = _oldSearchSource.ActionKeyword;
+            if (!PluginManager.ActionKeywordRegistered(keyword) || oldKeyword == newKeyword)
             {
-                var newKeyword = keyword;
-                var oldKeyword = _oldSearchSource.ActionKeyword;
                 var id = _context.CurrentPluginMetadata.ID;
                 PluginManager.ReplaceActionKeyword(id, oldKeyword, newKeyword);
 

--- a/Plugins/Wox.Plugin.WebSearch/SearchSourceSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.WebSearch/SearchSourceSetting.xaml.cs
@@ -96,10 +96,9 @@ namespace Wox.Plugin.WebSearch
 
         private void EditSearchSource()
         {
-            var keyword = _searchSource.ActionKeyword;
-            var newKeyword = keyword;
+            var newKeyword = _searchSource.ActionKeyword;
             var oldKeyword = _oldSearchSource.ActionKeyword;
-            if (!PluginManager.ActionKeywordRegistered(keyword) || oldKeyword == newKeyword)
+            if (!PluginManager.ActionKeywordRegistered(newKeyword) || oldKeyword == newKeyword)
             {
                 var id = _context.CurrentPluginMetadata.ID;
                 PluginManager.ReplaceActionKeyword(id, oldKeyword, newKeyword);


### PR DESCRIPTION
I fixed a bug where if you try to change a SearchSource without changing the action keyword you will receive a message the keyword is already assigned.
