### PR TITLE
Fixed checking for python also in the UserVariables

### DIFF
--- a/Wox.Core/Plugin/PluginsLoader.cs
+++ b/Wox.Core/Plugin/PluginsLoader.cs
@@ -81,8 +81,9 @@ namespace Wox.Core.Plugin
 
             if (string.IsNullOrEmpty(pythonDirecotry))
             {
-                var paths = Environment.GetEnvironmentVariable(PATH);
-                if (paths != null)
+                var paths = Environment.GetEnvironmentVariable(PATH, EnvironmentVariableTarget.Machine);
+                paths += Environment.GetEnvironmentVariable(PATH, EnvironmentVariableTarget.User);
+                if (!string.IsNullOrEmpty(paths))
                 {
                     var pythonPaths = paths.Split(';').Where(p => p.ToLower().Contains(Python));
                     if (pythonPaths.Any())


### PR DESCRIPTION
Currently the PluginsLoader just checks the environment block of the current process. The Python3 Windows installer puts the path of python only into the uservariables. Therefore it would be useful to look there also.
