### PR TITLE
fixed the origin root images directory of web search plugin 

### DIFF
--- a/Plugins/Wox.Plugin.WebSearch/SearchSourceSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.WebSearch/SearchSourceSetting.xaml.cs
@@ -119,7 +119,7 @@ namespace Wox.Plugin.WebSearch
 
         private void OnSelectIconClick(object sender, RoutedEventArgs e)
         {
-            var directory = Path.Combine(Main.ImagesDirectory, Main.Images);
+            var directory = Main.ImagesDirectory;
             const string filter = "Image files (*.jpg, *.jpeg, *.gif, *.png, *.bmp) |*.jpg; *.jpeg; *.gif; *.png; *.bmp";
             var dialog = new OpenFileDialog {InitialDirectory = directory, Filter = filter};
 


### PR DESCRIPTION
in `main.cs`  It already contains directory `Images`

``` C#
 ImagesDirectory = Path.Combine(pluginDirectory, Images);
```

https://github.com/Wox-launcher/Wox/blob/7a45884826ed375950e199f666c782c1e403fdfb/Plugins/Wox.Plugin.WebSearch/Main.cs#L132
