### PR TITLE
added various operator keywords to calculator

### DIFF
--- a/Plugins/Wox.Plugin.Calculator/Main.cs
+++ b/Plugins/Wox.Plugin.Calculator/Main.cs
@@ -10,7 +10,8 @@ namespace Wox.Plugin.Caculator
     {
         private static Regex regValidExpressChar = new Regex(
                         @"^(" +
-                        @"sin|cos|ceil|floor|exp|pi|max|min|det|arccos|abs|" +
+                        @"ceil|floor|exp|pi|e|max|min|det|abs|log|ln" +
+                        @"sin|cos|tan|arcsin|arccos|arctan|" +
                         @"eigval|eigvec|eig|sum|polar|plot|round|sort|real|zeta|" +
                         @"bin2dec|hex2dec|oct2dec|" +
                         @"==|~=|&&|\|\||" +


### PR DESCRIPTION
Added functions I commonly use on e.g. google calculator but were missed by calculator parser.

Specifically I added:
e (constant like pi)
tan, arcsin, and arctan
log and ln

A related note: YAMP supports a plethora of functions/operators beyond these that some people might want to use.  It's worth considering not doing any sort of parsing before passing to YAMP to allow users to access these without trying to hardcode every one in the Wox parser.  Not sure if that is plausible. 
