### PR TITLE
Improvements to UWP application indexing

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -47,8 +47,7 @@ namespace Wox.Plugin.Program.Programs
             InitializeAppInfo();
             Apps = Apps.Where(a =>
             {
-                var valid = !string.IsNullOrEmpty(a.Executable) &&
-                            !string.IsNullOrEmpty(a.UserModelId) &&
+                var valid = !string.IsNullOrEmpty(a.UserModelId) &&
                             !string.IsNullOrEmpty(a.DisplayName);
                 return valid;
             }).ToArray();
@@ -81,7 +80,6 @@ namespace Wox.Plugin.Program.Programs
                     if (appListEntry != "nonoe")
                     {
                         Apps[i].UserModelId = currentApp.GetAppUserModelId();
-                        Apps[i].Executable = currentApp.GetStringValue("Executable") ?? string.Empty;
                         Apps[i].BackgroundColor = currentApp.GetStringValue("BackgroundColor") ?? string.Empty;
                         Apps[i].LogoPath = Path.Combine(Location, currentApp.GetStringValue("Square44x44Logo"));
                         Apps[i].Location = Location;
@@ -208,7 +206,6 @@ namespace Wox.Plugin.Program.Programs
             public string Description { get; set; }
             public RandomAccessStreamReference LogoStream { get; set; }
             public string UserModelId { get; set; }
-            public string Executable { get; set; }
             public string PublisherDisplayName { get; set; }
             public string BackgroundColor { get; set; }
             public string LogoPath { get; set; }

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -155,24 +155,12 @@ namespace Wox.Plugin.Program.Programs
                 var userSecurityId = user.Value;
                 var packageManager = new PackageManager();
                 var packages = packageManager.FindPackagesForUser(userSecurityId);
-                packages = packages.Where(IsValidPackage);
+                packages = packages.Where(p => !p.IsFramework && !p.IsDevelopmentMode && !string.IsNullOrEmpty(p.InstalledLocation.Path));
                 return packages;
             }
             else
             {
                 return new Package[] { };
-            }
-        }
-
-        private static bool IsValidPackage(Package package)
-        {
-            try
-            {
-                return !package.IsFramework && !string.IsNullOrEmpty(package.InstalledLocation.Path);
-            }
-            catch (FileNotFoundException)
-            {
-                return false;
             }
         }
 

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -157,12 +157,24 @@ namespace Wox.Plugin.Program.Programs
                 var userSecurityId = user.Value;
                 var packageManager = new PackageManager();
                 var packages = packageManager.FindPackagesForUser(userSecurityId);
-                packages = packages.Where(p => !p.IsFramework && !string.IsNullOrEmpty(p.InstalledLocation.Path));
+                packages = packages.Where(IsValidPackage);
                 return packages;
             }
             else
             {
                 return new Package[] { };
+            }
+        }
+
+        private static bool IsValidPackage(Package package)
+        {
+            try
+            {
+                return !package.IsFramework && !string.IsNullOrEmpty(package.InstalledLocation.Path);
+            }
+            catch (FileNotFoundException)
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
I was testing out the UWP support and hit the same issue @talynone mentioned in https://github.com/Wox-launcher/Wox/issues/198#issuecomment-240597463.

I too have a `Package` that throws when the `InstalledLocation` property is accessed. With the current structure this exception will result in all packages being ignored instead of only the problem package. A simple try-catch while filtering the packages does the trick.

I also have Tweetium installed which is a WinJS based UWP app and does not have an `"Executable"` value in the manifest. As a result it is being filtered out in the UWP constructor. The Tweetium app can still be launched using its `UserModelId` so I don't think that the filter on `"Executable"` needs to be applied. I have removed this and can now also launch WinJS based applications. I've been running with these changes for about a week now and haven't noticed any problems.
