### PR TITLE
Update Themes URL link

### DIFF
--- a/Wox/ViewModel/SettingWindowViewModel.cs
+++ b/Wox/ViewModel/SettingWindowViewModel.cs
@@ -114,7 +114,7 @@ namespace Wox.ViewModel
 
         #region theme
 
-        public static string Theme => @"http://www.getwox.com/theme";
+        public static string Theme => @"http://www.getwox.com/theme/builder";
 
         public string SelectedTheme
         {


### PR DESCRIPTION
Old URL seems to not be valid anymore. It redirects to the main page.