### PR TITLE
add shortcut 'ctrl+l' to unselect query text

### DIFF
--- a/Wox/MainWindow.xaml
+++ b/Wox/MainWindow.xaml
@@ -37,6 +37,7 @@
         <KeyBinding Key="K" Modifiers="Ctrl" Command="{Binding SelectPrevItemCommand}"></KeyBinding>
         <KeyBinding Key="U" Modifiers="Ctrl" Command="{Binding SelectPrevPageCommand}"></KeyBinding>
         <KeyBinding Key="O" Modifiers="Ctrl" Command="{Binding LoadContextMenuCommand}"></KeyBinding>
+        <KeyBinding Key="L" Modifiers="Ctrl" Command="{Binding UnselectTextCommand}"></KeyBinding>
         <KeyBinding Key="H" Modifiers="Ctrl" Command="{Binding LoadHistoryCommand}"></KeyBinding>
         <KeyBinding Key="Enter" Modifiers="Shift" Command="{Binding LoadContextMenuCommand}"></KeyBinding>
         <KeyBinding Key="Enter" Command="{Binding OpenResultCommand}"></KeyBinding>

--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -185,6 +185,13 @@ namespace Wox.ViewModel
                     SelectedResults = Results;
                 }
             });
+
+            UnselectTextCommand = new RelayCommand(_ =>
+            {
+                var q = QueryText;
+                ChangeQueryText(q + " ");
+                ChangeQueryText(q);
+            });
         }
 
         #endregion
@@ -268,6 +275,7 @@ namespace Wox.ViewModel
         public ICommand LoadContextMenuCommand { get; set; }
         public ICommand LoadHistoryCommand { get; set; }
         public ICommand OpenResultCommand { get; set; }
+        public ICommand UnselectTextCommand { get; set; }
 
         #endregion
 


### PR DESCRIPTION
query text is selected when reopen wox, so i add a ctrl+l shortcut, doing the same thing as right arrow (->).

I use a very tricky way to do this.