### PR TITLE
Fixed typo in HelloWorldCSharp plugin

### DIFF
--- a/Plugins/HelloWorldCSharp/Main.cs
+++ b/Plugins/HelloWorldCSharp/Main.cs
@@ -13,7 +13,7 @@ namespace HelloWorldCSharp
         {
             var result = new Result
             {
-                Title = "Hello Word from CSharp",
+                Title = "Hello World from CSharp",
                 SubTitle = $"Query: {query.Search}",
                 IcoPath = "app.png"
             };


### PR DESCRIPTION
This was "Hello word" instead of "World"