### PR TITLE
context menu for python plugins

### DIFF
--- a/JsonRPC/wox.py
+++ b/JsonRPC/wox.py
@@ -12,19 +12,26 @@ class Wox(object):
     def __init__(self):
         rpc_request = json.loads(sys.argv[1])
         # proxy is not working now
-        self.proxy = rpc_request.get("proxy",{}) 
+        self.proxy = rpc_request.get("proxy",{})
         request_method_name = rpc_request.get("method")
         request_parameters = rpc_request.get("parameters")
         methods = inspect.getmembers(self, predicate=inspect.ismethod)
 
         request_method = dict(methods)[request_method_name]
         results = request_method(*request_parameters)
-        if request_method_name == "query":
+
+        if request_method_name == "query" or request_method_name == "context_menu":
             print(json.dumps({"result": results}))
 
     def query(self,query):
         """
         sub class need to override this method
+        """
+        return []
+
+    def context_menu(self, data):
+        """
+        optional context menu entries for a result
         """
         return []
 

--- a/Plugins/HelloWorldPython/main.py
+++ b/Plugins/HelloWorldPython/main.py
@@ -8,7 +8,17 @@ class HelloWorld(Wox):
         results = []
         results.append({
             "Title": "Hello World",
-            "SubTitle": "Query: {}".format(query),            
+            "SubTitle": "Query: {}".format(query),
+            "IcoPath":"Images/app.ico",
+            "ContextData": "ctxData"
+        })
+        return results
+
+    def context_menu(self, data):
+        results = []
+        results.append({
+            "Title": "Context menu entry",
+            "SubTitle": "Data: {}".format(data),
             "IcoPath":"Images/app.ico"
         })
         return results

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -36,7 +36,7 @@ function Copy-Resources ($path, $config) {
     $target = "$output\$config"
     Copy-Item -Recurse -Force $project\Themes\* $target\Themes\
     Copy-Item -Recurse -Force $project\Images\* $target\Images\
-    Copy-Item -Recurse -Force $path\Plugins\HelloWorldPython\* $target\Plugins\HelloWorldPython
+    Copy-Item -Recurse -Force $path\Plugins\HelloWorldPython $target\Plugins\HelloWorldPython
     Copy-Item -Recurse -Force $path\JsonRPC $target\JsonRPC
     Copy-Item -Force $path\packages\squirrel*\tools\Squirrel.exe $output\Update.exe
 }

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -36,7 +36,7 @@ function Copy-Resources ($path, $config) {
     $target = "$output\$config"
     Copy-Item -Recurse -Force $project\Themes\* $target\Themes\
     Copy-Item -Recurse -Force $project\Images\* $target\Images\
-    Copy-Item -Recurse -Force $path\Plugins\HelloWorldPython $target\Plugins\HelloWorldPython
+    Copy-Item -Recurse -Force $path\Plugins\HelloWorldPython\* $target\Plugins\HelloWorldPython
     Copy-Item -Recurse -Force $path\JsonRPC $target\JsonRPC
     Copy-Item -Force $path\packages\squirrel*\tools\Squirrel.exe $output\Update.exe
 }

--- a/Wox.Core/Plugin/ExecutablePlugin.cs
+++ b/Wox.Core/Plugin/ExecutablePlugin.cs
@@ -39,5 +39,16 @@ namespace Wox.Core.Plugin
             _startInfo.Arguments = $"\"{rpcRequest}\"";
             return Execute(_startInfo);
         }
+
+        protected override string ExecuteContextMenu(Result selectedResult) {
+            JsonRPCServerRequestModel request = new JsonRPCServerRequestModel {
+                Method = "contextmenu",
+                Parameters = new object[] { selectedResult.ContextData },
+            };
+
+            _startInfo.Arguments = $"\"{request}\"";
+
+            return Execute(_startInfo);
+        }
     }
 }

--- a/Wox.Core/Plugin/JsonPRCModel.cs
+++ b/Wox.Core/Plugin/JsonPRCModel.cs
@@ -71,7 +71,7 @@ namespace Wox.Core.Plugin
 
         private string GetParameterByType(object parameter)
         {
-            if (parameter is null) {
+            if (parameter == null) {
                 return "null";
             }
             if (parameter is string)

--- a/Wox.Core/Plugin/JsonPRCModel.cs
+++ b/Wox.Core/Plugin/JsonPRCModel.cs
@@ -56,7 +56,7 @@ namespace Wox.Core.Plugin
             string rpc = string.Empty;
             if (Parameters != null && Parameters.Length > 0)
             {
-                string parameters = Parameters.Aggregate("[", (current, o) => current + (GetParamterByType(o) + ","));
+                string parameters = Parameters.Aggregate("[", (current, o) => current + (GetParameterByType(o) + ","));
                 parameters = parameters.Substring(0, parameters.Length - 1) + "]";
                 rpc = string.Format(@"{{\""method\"":\""{0}\"",\""parameters\"":{1}", Method, parameters);
             }
@@ -69,25 +69,27 @@ namespace Wox.Core.Plugin
 
         }
 
-        private string GetParamterByType(object paramter)
+        private string GetParameterByType(object parameter)
         {
-
-            if (paramter is string)
-            {
-                return string.Format(@"\""{0}\""", RepalceEscapes(paramter.ToString()));
+            if (parameter is null) {
+                return "null";
             }
-            if (paramter is int || paramter is float || paramter is double)
+            if (parameter is string)
             {
-                return string.Format(@"{0}", paramter);
+                return string.Format(@"\""{0}\""", ReplaceEscapes(parameter.ToString()));
             }
-            if (paramter is bool)
+            if (parameter is int || parameter is float || parameter is double)
             {
-                return string.Format(@"{0}", paramter.ToString().ToLower());
+                return string.Format(@"{0}", parameter);
             }
-            return paramter.ToString();
+            if (parameter is bool)
+            {
+                return string.Format(@"{0}", parameter.ToString().ToLower());
+            }
+            return parameter.ToString();
         }
 
-        private string RepalceEscapes(string str)
+        private string ReplaceEscapes(string str)
         {
             return str.Replace(@"\", @"\\") //Escapes in ProcessStartInfo
                 .Replace(@"\", @"\\") //Escapes itself when passed to client

--- a/Wox.Core/Plugin/JsonRPCPlugin.cs
+++ b/Wox.Core/Plugin/JsonRPCPlugin.cs
@@ -17,7 +17,7 @@ namespace Wox.Core.Plugin
     /// Represent the plugin that using JsonPRC
     /// every JsonRPC plugin should has its own plugin instance
     /// </summary>
-    internal abstract class JsonRPCPlugin : IPlugin
+    internal abstract class JsonRPCPlugin : IPlugin, IContextMenu
     {
         protected PluginInitContext context;
         public const string JsonRPC = "JsonRPC";
@@ -29,56 +29,71 @@ namespace Wox.Core.Plugin
 
         protected abstract string ExecuteQuery(Query query);
         protected abstract string ExecuteCallback(JsonRPCRequestModel rpcRequest);
+        protected abstract string ExecuteContextMenu(Result selectedResult);
 
         public List<Result> Query(Query query)
         {
             string output = ExecuteQuery(query);
-            if (!String.IsNullOrEmpty(output))
-            {
-                try
+            try {
+                return DeserializeResult(output);
+            }
+            catch (Exception e) {
+                Log.Exception($"|JsonRPCPlugin.Query|Exception when query <{query}>", e);
+                return null;
+            }
+        }
+
+        public List<Result> LoadContextMenus(Result selectedResult) {
+            string output = ExecuteContextMenu(selectedResult);
+            try {
+                return DeserializeResult(output);
+            }
+            catch (Exception e) {
+                Log.Exception($"|JsonRPCPlugin.LoadContextMenus|Exception on result <{selectedResult}>", e);
+                return null;
+            }
+        }
+
+        private List<Result> DeserializeResult(string output) {
+            if (!String.IsNullOrEmpty(output)) {
+                List<Result> results = new List<Result>();
+
+                JsonRPCQueryResponseModel queryResponseModel = JsonConvert.DeserializeObject<JsonRPCQueryResponseModel>(output);
+                if (queryResponseModel.Result == null) return null;
+
+                foreach (JsonRPCResult result in queryResponseModel.Result)
                 {
-                    List<Result> results = new List<Result>();
-
-                    JsonRPCQueryResponseModel queryResponseModel = JsonConvert.DeserializeObject<JsonRPCQueryResponseModel>(output);
-                    if (queryResponseModel.Result == null) return null;
-
-                    foreach (JsonRPCResult result in queryResponseModel.Result)
+                    JsonRPCResult result1 = result;
+                    result.Action = c =>
                     {
-                        JsonRPCResult result1 = result;
-                        result.Action = c =>
-                        {
-                            if (result1.JsonRPCAction == null) return false;
+                        if (result1.JsonRPCAction == null) return false;
 
-                            if (!String.IsNullOrEmpty(result1.JsonRPCAction.Method))
+                        if (!String.IsNullOrEmpty(result1.JsonRPCAction.Method))
+                        {
+                            if (result1.JsonRPCAction.Method.StartsWith("Wox."))
                             {
-                                if (result1.JsonRPCAction.Method.StartsWith("Wox."))
+                                ExecuteWoxAPI(result1.JsonRPCAction.Method.Substring(4), result1.JsonRPCAction.Parameters);
+                            }
+                            else
+                            {
+                                string actionReponse = ExecuteCallback(result1.JsonRPCAction);
+                                JsonRPCRequestModel jsonRpcRequestModel = JsonConvert.DeserializeObject<JsonRPCRequestModel>(actionReponse);
+                                if (jsonRpcRequestModel != null
+                                    && !String.IsNullOrEmpty(jsonRpcRequestModel.Method)
+                                    && jsonRpcRequestModel.Method.StartsWith("Wox."))
                                 {
-                                    ExecuteWoxAPI(result1.JsonRPCAction.Method.Substring(4), result1.JsonRPCAction.Parameters);
-                                }
-                                else
-                                {
-                                    string actionReponse = ExecuteCallback(result1.JsonRPCAction);
-                                    JsonRPCRequestModel jsonRpcRequestModel = JsonConvert.DeserializeObject<JsonRPCRequestModel>(actionReponse);
-                                    if (jsonRpcRequestModel != null
-                                        && !String.IsNullOrEmpty(jsonRpcRequestModel.Method)
-                                        && jsonRpcRequestModel.Method.StartsWith("Wox."))
-                                    {
-                                        ExecuteWoxAPI(jsonRpcRequestModel.Method.Substring(4), jsonRpcRequestModel.Parameters);
-                                    }
+                                    ExecuteWoxAPI(jsonRpcRequestModel.Method.Substring(4), jsonRpcRequestModel.Parameters);
                                 }
                             }
-                            return !result1.JsonRPCAction.DontHideAfterAction;
-                        };
-                        results.Add(result);
-                    }
-                    return results;
+                        }
+                        return !result1.JsonRPCAction.DontHideAfterAction;
+                    };
+                    results.Add(result);
                 }
-                catch (Exception e)
-                {
-                    Log.Exception($"|JsonRPCPlugin.Query|Exception when query <{query}>", e);
-                }
+                return results;
+            } else {
+                return null;
             }
-            return null;
         }
 
         private void ExecuteWoxAPI(string method, object[] parameters)

--- a/Wox.Core/Plugin/PythonPlugin.cs
+++ b/Wox.Core/Plugin/PythonPlugin.cs
@@ -49,5 +49,16 @@ namespace Wox.Core.Plugin
             _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
             return Execute(_startInfo);
         }
+
+        protected override string ExecuteContextMenu(Result selectedResult) {
+            JsonRPCServerRequestModel request = new JsonRPCServerRequestModel {
+                Method = "context_menu",
+                Parameters = new object[] { selectedResult.ContextData },
+            };
+            _startInfo.Arguments = $"-B \"{context.CurrentPluginMetadata.ExecuteFilePath}\" \"{request}\"";
+            _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
+
+            return Execute(_startInfo);
+        }
     }
 }


### PR DESCRIPTION
Added context menu for python plugins.

I also updated the HelloWorld python example. The data parameter in "context_menu" is the passed context data.

This change also affects ExecutablePlugin.
https://github.com/Wox-launcher/Wox/compare/master...medoni:master#diff-ab61c87f81bd4fdb87cf6e8a96d6a696
The change in ExecutablePlugin was not tested. (missing example)
