### PR TITLE
ImageLoader - Windows Thumbnail Cache

### DIFF
--- a/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/Wox.Infrastructure/Image/ImageLoader.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Wox.Infrastructure.Logger;
 using Wox.Infrastructure.Storage;
+using Wox.Infrastructure.UserSettings;
 
 namespace Wox.Infrastructure.Image
 {
@@ -17,8 +18,7 @@ namespace Wox.Infrastructure.Image
     {
         private static readonly ImageCache ImageCache = new ImageCache();
         private static BinaryStorage<ConcurrentDictionary<string, int>> _storage;
-
-        public static bool UseWindowsThumbnailCache = true;
+        
         private static int ThumbnailCacheSize = 2 * 32; // for high resolution display, use double size
 
         private static readonly string[] ImageExtions =
@@ -32,9 +32,12 @@ namespace Wox.Infrastructure.Image
             ".ico"
         };
 
+        private static Settings _settings;
 
-        public static void Initialize()
+        public static void Initialize(Settings settings)
         {
+            _settings = settings;
+
             _storage = new BinaryStorage<ConcurrentDictionary<string, int>> ("Image");
             ImageCache.Usage = _storage.TryLoad(new ConcurrentDictionary<string, int>());
 
@@ -126,7 +129,7 @@ namespace Wox.Infrastructure.Image
                 {
                     if (Directory.Exists(path))
                     {
-                        if (UseWindowsThumbnailCache) 
+                        if (_settings.UseWindowThumbnailCache) 
                         {
                             image = GetBitmapFromPath(path);
                         } 
@@ -137,7 +140,7 @@ namespace Wox.Infrastructure.Image
                     }
                     else if (File.Exists(path))
                     {
-                        if (UseWindowsThumbnailCache) 
+                        if (_settings.UseWindowThumbnailCache) 
                         {
                             image = GetBitmapFromPath(path);
                         }
@@ -182,7 +185,7 @@ namespace Wox.Infrastructure.Image
         private static ImageSource GetBitmapFromPath(string path) 
         {
             
-            if (UseWindowsThumbnailCache)
+            if (_settings.UseWindowThumbnailCache)
             {
                 string ext = Path.GetExtension(path);
                 if (!WindowsThumbnailCacheAPI.NotCachableExtensions.Contains(ext)) { // check if extension is cachable

--- a/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/Wox.Infrastructure/Image/ImageLoader.cs
@@ -18,7 +18,7 @@ namespace Wox.Infrastructure.Image
         private static readonly ImageCache ImageCache = new ImageCache();
         private static BinaryStorage<ConcurrentDictionary<string, int>> _storage;
 
-        private static bool UseWindowsThumbnailCache = true;
+        public static bool UseWindowsThumbnailCache = true;
         private static int ThumbnailCacheSize = 2 * 32; // for high resolution display, use double size
 
         private static readonly string[] ImageExtions =

--- a/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/Wox.Infrastructure/Image/ImageLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -21,7 +22,7 @@ namespace Wox.Infrastructure.Image
         
         private static int ThumbnailCacheSize = 2 * 32; // for high resolution display, use double size
 
-        private static readonly string[] ImageExtions =
+        private static readonly HashSet<string> ImageExtions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             ".png",
             ".jpg",
@@ -146,7 +147,7 @@ namespace Wox.Infrastructure.Image
                         }
                         else 
                         {
-                            var externsion = Path.GetExtension(path).ToLower();
+                            var externsion = Path.GetExtension(path);
                             if (ImageExtions.Contains(externsion))
                             {
                                 image = new BitmapImage(new Uri(path));
@@ -196,7 +197,7 @@ namespace Wox.Infrastructure.Image
                     }
                 }
 
-                if (ImageExtions.Contains(ext.ToLower())) {
+                if (ImageExtions.Contains(ext)) {
                     // fallback for images (eg. ico files)
                     var img = new BitmapImage();
                     img.BeginInit();

--- a/Wox.Infrastructure/Image/WindowsThumbnailCacheAPI.cs
+++ b/Wox.Infrastructure/Image/WindowsThumbnailCacheAPI.cs
@@ -1,0 +1,227 @@
+﻿
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace Wox.Infrastructure.Image 
+{
+    static class WindowsThumbnailCacheAPI 
+    {
+        private static readonly IThumbnailCache _cache;
+
+        public static readonly HashSet<string> NotCachableExtensions;
+
+        static WindowsThumbnailCacheAPI() {
+            NotCachableExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+                ".lnk",
+                ".exe",
+                ".bat",
+                ".cmd",
+                ".pif",
+                ".appref-ms"
+            };
+
+            Guid CLSID_LocalThumbnailCache = new Guid("50EF4544-AC9F-4A8E-B21B-8A26180DB13F");
+            _cache = (IThumbnailCache)Activator.CreateInstance(Type.GetTypeFromCLSID(CLSID_LocalThumbnailCache));
+        }
+
+        public static ImageSource GetThumbnail(string path, int size) {
+            IShellItem item = GetShellItemFromPath(path);
+            if (item == null) {
+                return null;
+            }
+
+
+            ISharedBitmap bitmap = null;
+            IntPtr hBitmap = IntPtr.Zero;
+            try {
+
+                
+                WTS_CACHEFLAGS cacheFlags;
+                WTS_THUMBNAILID thumbid;
+
+                uint ret;
+
+                ret = _cache.GetThumbnail(item, (uint)size, WTS_FLAGS.WTS_EXTRACT, out bitmap, out cacheFlags, out thumbid);
+
+                if (ret != 0 || bitmap == null) {
+                    return null;
+                }
+
+                hBitmap = IntPtr.Zero;
+                bitmap.Detach(out hBitmap);
+
+
+                var iSrc = Imaging.CreateBitmapSourceFromHBitmap(
+                    hBitmap, IntPtr.Zero, Int32Rect.Empty,
+                    BitmapSizeOptions.FromEmptyOptions()
+                );
+
+                iSrc.Freeze();
+                
+                return iSrc;    
+            } finally {
+                if (item != null) Marshal.ReleaseComObject(item);
+                if (hBitmap != IntPtr.Zero) { DeleteObject(hBitmap); }
+                if (bitmap != null) Marshal.ReleaseComObject(bitmap); 
+            }
+        }
+
+
+        private static IShellItem GetShellItemFromPath(string path) {
+            if (!Path.IsPathRooted(path)) {
+                path = Path.Combine(Environment.CurrentDirectory, path);
+            }
+
+            path = Path.GetFullPath(path); //converts / to \
+
+            IShellItem item = null;
+            IntPtr idl;
+            uint atts = 0;
+
+            if ((SHILCreateFromPath(path, out idl, ref atts) == 0) &&
+                (SHCreateShellItem(IntPtr.Zero, IntPtr.Zero, idl, out item) == 0)) {
+
+                return item;
+            } else {
+                return null;
+            }
+        }
+
+
+        [ComImport]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("F676C15D-596A-4ce2-8234-33996F445DB1")]
+        private interface IThumbnailCache {
+            uint GetThumbnail(
+                [In] IShellItem pShellItem,
+                [In] uint cxyRequestedThumbSize,
+                [In] WTS_FLAGS flags /*default:  WTS_FLAGS.WTS_EXTRACT*/,
+                [Out][MarshalAs(UnmanagedType.Interface)] out ISharedBitmap ppvThumb,
+                [Out] out WTS_CACHEFLAGS pOutFlags,
+                [Out] out WTS_THUMBNAILID pThumbnailID
+            );
+
+            void GetThumbnailByID(
+                [In, MarshalAs(UnmanagedType.Struct)] WTS_THUMBNAILID thumbnailID,
+                [In] uint cxyRequestedThumbSize,
+                [Out][MarshalAs(UnmanagedType.Interface)] out ISharedBitmap ppvThumb,
+                [Out] out WTS_CACHEFLAGS pOutFlags
+            );
+        }
+
+        [Flags]
+        enum WTS_FLAGS : uint {
+            WTS_EXTRACT = 0x00000000,
+            WTS_INCACHEONLY = 0x00000001,
+            WTS_FASTEXTRACT = 0x00000002,
+            WTS_SLOWRECLAIM = 0x00000004,
+            WTS_FORCEEXTRACTION = 0x00000008,
+            WTS_EXTRACTDONOTCACHE = 0x00000020,
+            WTS_SCALETOREQUESTEDSIZE = 0x00000040,
+            WTS_SKIPFASTEXTRACT = 0x00000080,
+            WTS_EXTRACTINPROC = 0x00000100
+        }
+
+        [Flags]
+        enum WTS_CACHEFLAGS : uint {
+            WTS_DEFAULT = 0x00000000,
+            WTS_LOWQUALITY = 0x00000001,
+            WTS_CACHED = 0x00000002
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 16), Serializable]
+        struct WTS_THUMBNAILID {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            byte[] rgbKey;
+        }
+
+        [ComImport()]
+        [Guid("091162a4-bc96-411f-aae8-c5122cd03363")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface ISharedBitmap {
+            uint Detach(
+                [Out] out IntPtr phbm
+            );
+
+            uint GetFormat(
+                [Out]  out WTS_ALPHATYPE pat
+            );
+
+            uint GetSharedBitmap(
+                [Out] out IntPtr phbm
+            );
+
+            uint GetSize(
+                [Out, MarshalAs(UnmanagedType.Struct)] out SIZE pSize
+            );
+
+            uint InitializeBitmap(
+                [In]  IntPtr hbm,
+                [In]  WTS_ALPHATYPE wtsAT
+            );
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SIZE {
+            private int cx;
+            private int cy;
+
+            private SIZE(int cx, int cy) {
+                this.cx = cx;
+                this.cy = cy;
+            }
+        }
+
+        private enum WTS_ALPHATYPE : uint {
+            WTSAT_UNKNOWN = 0,
+            WTSAT_RGB = 1,
+            WTSAT_ARGB = 2
+        }
+
+        [ComImport]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe")]
+        private interface IShellItem {
+            void BindToHandler(IntPtr pbc,
+                [MarshalAs(UnmanagedType.LPStruct)]Guid bhid,
+                [MarshalAs(UnmanagedType.LPStruct)]Guid riid,
+                out IntPtr ppv);
+
+            void GetParent(out IShellItem ppsi);
+
+            void GetDisplayName(SIGDN sigdnName, out IntPtr ppszName);
+
+            void GetAttributes(uint sfgaoMask, out uint psfgaoAttribs);
+
+            void Compare(IShellItem psi, uint hint, out int piOrder);
+        }
+
+        private enum SIGDN : uint {
+            NORMALDISPLAY = 0,
+            PARENTRELATIVEPARSING = 0x80018001,
+            PARENTRELATIVEFORADDRESSBAR = 0x8001c001,
+            DESKTOPABSOLUTEPARSING = 0x80028000,
+            PARENTRELATIVEEDITING = 0x80031001,
+            DESKTOPABSOLUTEEDITING = 0x8004c000,
+            FILESYSPATH = 0x80058000,
+            URL = 0x80068000
+        }
+
+        [DllImport("shell32.dll", PreserveSig = true)]
+        private static extern int SHCreateShellItem(IntPtr pidlParent, IntPtr psfParent, IntPtr pidl, out IShellItem ppsi);
+
+        [DllImport("shell32.dll")]
+        private static extern int SHILCreateFromPath([MarshalAs(UnmanagedType.LPWStr)] string pszPath, out IntPtr ppIdl, ref uint rgflnOut);
+
+        [DllImport("gdi32.dll")]
+        private static extern bool DeleteObject(IntPtr handle);
+
+    }
+}

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -49,10 +49,7 @@ namespace Wox.Infrastructure.UserSettings
         public bool RememberLastLaunchLocation { get; set; }
         public bool IgnoreHotkeysOnFullscreen { get; set; }
 
-        public bool UseWindowThumbnailCache {
-            get { return Image.ImageLoader.UseWindowsThumbnailCache; }
-            set { Image.ImageLoader.UseWindowsThumbnailCache = value; }
-        }
+        public bool UseWindowThumbnailCache { get; set; }
 
         public HttpProxy Proxy { get; set; } = new HttpProxy();
 

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -49,6 +49,11 @@ namespace Wox.Infrastructure.UserSettings
         public bool RememberLastLaunchLocation { get; set; }
         public bool IgnoreHotkeysOnFullscreen { get; set; }
 
+        public bool UseWindowThumbnailCache {
+            get { return Image.ImageLoader.UseWindowsThumbnailCache; }
+            set { Image.ImageLoader.UseWindowsThumbnailCache = value; }
+        }
+
         public HttpProxy Proxy { get; set; } = new HttpProxy();
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/Wox.Infrastructure/Wox.Infrastructure.csproj
+++ b/Wox.Infrastructure/Wox.Infrastructure.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Hotkey\KeyEvent.cs" />
     <Compile Include="Image\ImageCache.cs" />
     <Compile Include="Image\ImageLoader.cs" />
+    <Compile Include="Image\WindowsThumbnailCacheAPI.cs" />
     <Compile Include="Logger\Log.cs" />
     <Compile Include="Storage\ISavable.cs" />
     <Compile Include="Storage\PluginJsonStorage.cs" />

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -48,11 +48,11 @@ namespace Wox
                 RegisterAppDomainExceptions();
                 RegisterDispatcherUnhandledException();
 
-                ImageLoader.Initialize();
-                Alphabet.Initialize();
-
                 _settingsVM = new SettingWindowViewModel();
                 _settings = _settingsVM.Settings;
+
+                ImageLoader.Initialize(_settings);
+                Alphabet.Initialize();
 
                 PluginManager.LoadPlugins(_settings.PluginSettings);
                 _mainVM = new MainViewModel(_settings);

--- a/Wox/Languages/en.xaml
+++ b/Wox/Languages/en.xaml
@@ -32,6 +32,7 @@
     <system:String x:Key="autoUpdates">Auto Update</system:String>
     <system:String x:Key="selectPythonDirectory">Select</system:String>
     <system:String x:Key="hideOnStartup">Hide Wox on startup</system:String>
+    <system:String x:Key="useWindowsThumbnailCache">Use Windows thumbnail cache (Experimental, requires restart)</system:String>
 
     <!--Setting Plugin-->
     <system:String x:Key="plugin">Plugin</system:String>

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -75,6 +75,9 @@
                     <Button Margin="10" Click="OnSelectPythonDirectoryClick"
                             Content="{DynamicResource selectPythonDirectory}" />
                 </StackPanel>
+                <CheckBox Margin="10" IsChecked="{Binding Settings.UseWindowThumbnailCache}">
+                    <TextBlock Text="{DynamicResource useWindowsThumbnailCache}" />
+                </CheckBox>
             </StackPanel>
         </TabItem>
         <TabItem Header="{DynamicResource plugin}">


### PR DESCRIPTION
Please have a look to this PR. The ImageLoader uses now the Windows Thumbnail Cache API (configurable in Settings Window).

That PR solves 3 Problems for me:
- #1350 Memory usage optimization on ImageLoader
- Using of SVG Icons (Icon Preview). WPF doesn't support SVG Images
- Folder Plugin with Network Shares. 

The Thumbnail Cache API uses all installed Thumbnail Cache providers. For SVG I have installed https://svgextension.codeplex.com/

Testet on Windows 7 64bit


