### PR TITLE
Add 'Pause Command Prompt after command execution' option to shell plugin, and set default to false.

### DIFF
--- a/Plugins/Wox.Plugin.Shell/Languages/de.xaml
+++ b/Plugins/Wox.Plugin.Shell/Languages/de.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="wox_plugin_cmd_relace_winr">Ersetzt Win+R</system:String>
     <system:String x:Key="wox_plugin_cmd_leave_cmd_open">Schließe die Kommandozeilte nicht nachdem der Befehl ausgeführt wurde</system:String>
+    <system:String x:Key="wox_plugin_cmd_leave_cmd_pause">Pause die Kommandozeilte nachdem der Befehl ausgeführt wurde</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_name">Kommandozeile</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_description">Bereitstellung der Kommandozeile in Wox. Befehle müssem mit > starten</system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">Dieser Befehl wurde {0} mal ausgeführt</system:String>

--- a/Plugins/Wox.Plugin.Shell/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Shell/Languages/en.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="wox_plugin_cmd_relace_winr">Replace Win+R</system:String>
     <system:String x:Key="wox_plugin_cmd_leave_cmd_open">Do not close Command Prompt after command execution</system:String>
+    <system:String x:Key="wox_plugin_cmd_leave_cmd_pause">Pause Command Prompt after command execution</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_name">Shell</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_description">Allows to execute system commands from Wox. Commands should start with ></system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">this command has been executed {0} times</system:String>

--- a/Plugins/Wox.Plugin.Shell/Languages/pl.xaml
+++ b/Plugins/Wox.Plugin.Shell/Languages/pl.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="wox_plugin_cmd_relace_winr">Zastąp Win+R</system:String>
     <system:String x:Key="wox_plugin_cmd_leave_cmd_open">Nie zamykaj wiersza poleceń po wykonaniu polecenia</system:String>
+    <system:String x:Key="wox_plugin_cmd_leave_cmd_pause">Pauza wiersza poleceń po wykonaniu polecenia</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_name">Wiersz poleceń</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_description">Pozwala wykonywać komend wiersza polecania z Woxa. Polecania zaczynają się od ></system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">to polecenie zostało wykonane {0} razy</system:String>

--- a/Plugins/Wox.Plugin.Shell/Languages/zh-cn.xaml
+++ b/Plugins/Wox.Plugin.Shell/Languages/zh-cn.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="wox_plugin_cmd_relace_winr">替换 Win+R</system:String>
     <system:String x:Key="wox_plugin_cmd_leave_cmd_open">执行后不关闭命令窗口</system:String>
+    <system:String x:Key="wox_plugin_cmd_leave_cmd_pause">执行后暂停命令窗口</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_name">命令行</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_description">提供从Wox中执行命令行的能力，命令应该以>开头</system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">此命令已经被执行了 {0} 次</system:String>

--- a/Plugins/Wox.Plugin.Shell/Languages/zh-tw.xaml
+++ b/Plugins/Wox.Plugin.Shell/Languages/zh-tw.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="wox_plugin_cmd_relace_winr">取代 Win+R</system:String>
     <system:String x:Key="wox_plugin_cmd_leave_cmd_open">執行後不關閉命令提示字元視窗</system:String>
+    <system:String x:Key="wox_plugin_cmd_leave_cmd_pause">執行後暫停命令提示字元視窗</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_name">命令提示字元</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_description">提供從 Wox 中執行命令提示字元的功能，指令應該以>開頭</system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">此指令已執行了 {0} 次</system:String>

--- a/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/Plugins/Wox.Plugin.Shell/Main.cs
@@ -168,7 +168,8 @@ namespace Wox.Plugin.Shell
             ProcessStartInfo info;
             if (_settings.Shell == Shell.Cmd)
             {
-                var arguments = _settings.LeaveShellOpen ? $"/k \"{command}\"" : $"/c \"{command}\" & pause";
+                var arguments = _settings.LeaveShellOpen ? $"/k \"{command}\"" :
+                    _settings.LeaveShellPause ? $"/c \"{command}\" & pause" : $"/c \"{command}\"";
                 info = new ProcessStartInfo
                 {
                     FileName = "cmd.exe",
@@ -182,9 +183,13 @@ namespace Wox.Plugin.Shell
                 {
                     arguments = $"-NoExit \"{command}\"";
                 }
-                else
+                else if(_settings.LeaveShellPause)
                 {
                     arguments = $"\"{command} ; Read-Host -Prompt \\\"Press Enter to continue\\\"\"";
+                }
+                else
+                {
+                    arguments = $"\"{command}\"";
                 }
                 info = new ProcessStartInfo
                 {

--- a/Plugins/Wox.Plugin.Shell/Settings.cs
+++ b/Plugins/Wox.Plugin.Shell/Settings.cs
@@ -7,6 +7,7 @@ namespace Wox.Plugin.Shell
         public Shell Shell { get; set; } = Shell.Cmd;
         public bool ReplaceWinR { get; set; } = true;
         public bool LeaveShellOpen { get; set; }
+        public bool LeaveShellPause { get; set; }
         public Dictionary<string, int> Count = new Dictionary<string, int>();
 
         public void AddCmdHistory(string cmdName)

--- a/Plugins/Wox.Plugin.Shell/ShellSetting.xaml
+++ b/Plugins/Wox.Plugin.Shell/ShellSetting.xaml
@@ -12,10 +12,12 @@
                 <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <CheckBox Grid.Row="0" x:Name="ReplaceWinR" Content="{DynamicResource wox_plugin_cmd_relace_winr}" Margin="10" HorizontalAlignment="Left"/>
             <CheckBox Grid.Row="1" x:Name="LeaveShellOpen" Content="{DynamicResource wox_plugin_cmd_leave_cmd_open}" Margin="10" HorizontalAlignment="Left"/>
-            <ComboBox Grid.Row="2" x:Name="ShellComboBox" Margin="10" HorizontalAlignment="Left" >
+            <CheckBox Grid.Row="2" x:Name="LeaveShellPause" Content="{DynamicResource wox_plugin_cmd_leave_cmd_pause}" Margin="10" HorizontalAlignment="Left"/>
+            <ComboBox Grid.Row="3" x:Name="ShellComboBox" Margin="10" HorizontalAlignment="Left" >
                 <ComboBoxItem>CMD</ComboBoxItem>
                 <ComboBoxItem>PowerShell</ComboBoxItem>
                 <ComboBoxItem>RunCommand</ComboBoxItem>

--- a/Plugins/Wox.Plugin.Shell/ShellSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.Shell/ShellSetting.xaml.cs
@@ -29,6 +29,19 @@ namespace Wox.Plugin.Shell
                 _settings.LeaveShellOpen = false;
             };
 
+            LeaveShellPause.IsChecked = _settings.LeaveShellPause;
+            LeaveShellPause.IsEnabled = LeaveShellOpen.IsEnabled && !(LeaveShellOpen.IsChecked ?? false);
+
+            LeaveShellPause.Checked += (o, e) =>
+            {
+                _settings.LeaveShellPause = true;
+            };
+
+            LeaveShellPause.Unchecked += (o, e) =>
+            {
+                _settings.LeaveShellPause = false;
+            };
+
             ReplaceWinR.Checked += (o, e) =>
             {
                 _settings.ReplaceWinR = true;
@@ -43,6 +56,7 @@ namespace Wox.Plugin.Shell
             {
                 _settings.Shell = (Shell) ShellComboBox.SelectedIndex;
                 LeaveShellOpen.IsEnabled = _settings.Shell != Shell.RunCommand;
+                LeaveShellPause.IsEnabled = LeaveShellOpen.IsEnabled && !(LeaveShellOpen.IsChecked ?? false);
             };
         }
     }


### PR DESCRIPTION
Add 'Pause Command Prompt after command execution' option to shell plugin, and set default to false.