### PR TITLE
Execute the OpenResultComand with Ctrl and Alt modifiers when pressing enter

### DIFF
--- a/Wox/MainWindow.xaml
+++ b/Wox/MainWindow.xaml
@@ -40,6 +40,8 @@
         <KeyBinding Key="H" Modifiers="Ctrl" Command="{Binding LoadHistoryCommand}"></KeyBinding>
         <KeyBinding Key="Enter" Modifiers="Shift" Command="{Binding LoadContextMenuCommand}"></KeyBinding>
         <KeyBinding Key="Enter" Command="{Binding OpenResultCommand}"></KeyBinding>
+        <KeyBinding Key="Enter" Modifiers="Ctrl" Command="{Binding OpenResultCommand}"></KeyBinding>
+        <KeyBinding Key="Enter" Modifiers="Alt" Command="{Binding OpenResultCommand}"></KeyBinding>
         <KeyBinding Key="D1" Modifiers="Alt" Command="{Binding OpenResultCommand}" CommandParameter="0"></KeyBinding>
         <KeyBinding Key="D2" Modifiers="Alt" Command="{Binding OpenResultCommand}" CommandParameter="1"></KeyBinding>
         <KeyBinding Key="D3" Modifiers="Alt" Command="{Binding OpenResultCommand}" CommandParameter="2"></KeyBinding>


### PR DESCRIPTION
The folder plugin says to press Ctrl+Enter to open the folder, but this didn't actually work because the OpenResultCommand was not executed on Ctrl+Enter (Ctrl+mouse click worked fine though).