### PR TITLE
Cache fix

### DIFF
--- a/Wox.Infrastructure/Storage/BinaryStorage.cs
+++ b/Wox.Infrastructure/Storage/BinaryStorage.cs
@@ -30,19 +30,17 @@ namespace Wox.Infrastructure.Storage
         {
             if (File.Exists(FilePath))
             {
+                if (new FileInfo(FilePath).Length == 0)
+                {
+                    Log.Error($"|BinaryStorage.TryLoad|Zero length cache file <{FilePath}>");
+                    Save(defaultData);
+                    return defaultData;
+                }
+
                 using (var stream = new FileStream(FilePath, FileMode.Open))
                 {
-                    if (stream.Length > 0)
-                    {
-                        var d = Deserialize(stream, defaultData);
-                        return d;
-                    }
-                    else
-                    {
-                        Log.Error($"|BinaryStorage.TryLoad|Zero length cache file <{FilePath}>");
-                        Save(defaultData);
-                        return defaultData;
-                    }
+                    var d = Deserialize(stream, defaultData);
+                    return d;
                 }
             }
             else


### PR DESCRIPTION
Fixes #1394 and all related issues.

BinaryStorage.Save was being called inside of an open file stream, thus opening a second stream  which caused the locking error. 