### PR TITLE
Changed exception formatting back to default ToString call

### DIFF
--- a/Wox/ReportWindow.xaml.cs
+++ b/Wox/ReportWindow.xaml.cs
@@ -37,10 +37,7 @@ namespace Wox
             content.AppendLine(ErrorReporting.DependenciesInfo());
             content.AppendLine($"Date: {DateTime.Now.ToString(CultureInfo.InvariantCulture)}");
             content.AppendLine("Exception:");
-            content.AppendLine(exception.Source);
-            content.AppendLine(exception.GetType().ToString());
-            content.AppendLine(exception.Message);
-            content.AppendLine(exception.StackTrace);
+            content.AppendLine(exception.ToString());
             paragraph = new Paragraph();
             paragraph.Inlines.Add(content.ToString());
             ErrorTextbox.Document.Blocks.Add(paragraph);


### PR DESCRIPTION
Changed exception formatting from a per-property approach back to a standard ToString call.

Previous code would not account for exceptions like `AggregateException` and in general provided less information which usually proved worthless without a log file. 