### PR TITLE
Program paths fix + #1779

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -236,7 +236,6 @@ namespace Wox.Plugin.Program.Programs
                     Log.Exception($"|Program.Win32.ProgramPaths|Don't have permission on <{currentDirectory}>", e);
                 }
             } while (folderQueue.Any());
-            Log.Debug(string.Join("\n", files));
             return files;
         }
 

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -206,28 +206,38 @@ namespace Wox.Plugin.Program.Programs
         {
             if (!Directory.Exists(directory))
                 return new string[] { };
-
-            var ds = Directory.GetDirectories(directory);
-
-            var paths = ds.SelectMany(d =>
+            var files = new List<string>();
+            var folderQueue = new Queue<string>();
+            folderQueue.Enqueue(directory);
+            do
             {
+                var currentDirectory = folderQueue.Dequeue();
                 try
                 {
-                    var paths_for_suffixes = suffixes.SelectMany(s =>
+                    foreach (var suffix in suffixes)
                     {
-                        var pattern = $"*.{s}";
-                        var ps = Directory.EnumerateFiles(d, pattern, SearchOption.AllDirectories);
-                        return ps;
-                    });
-                    return paths_for_suffixes;
+                        files.AddRange(Directory.EnumerateFiles(currentDirectory, $"*.{suffix}", SearchOption.TopDirectoryOnly));
+                    }
                 }
                 catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
                 {
-                    Log.Exception($"|Program.Win32.ProgramPaths|Don't have permission on <{directory}>", e);
-                    return new List<string>();
+                    Log.Exception($"|Program.Win32.ProgramPaths|Don't have permission on <{currentDirectory}>", e);
                 }
-            });
-            return paths;
+
+                try
+                {
+                    foreach (var childDirectory in Directory.EnumerateDirectories(currentDirectory, "*", SearchOption.TopDirectoryOnly))
+                    {
+                        folderQueue.Enqueue(childDirectory);
+                    }
+                }
+                catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+                {
+                    Log.Exception($"|Program.Win32.ProgramPaths|Don't have permission on <{currentDirectory}>", e);
+                }
+            } while (folderQueue.Any());
+            Log.Debug(string.Join("\n", files));
+            return files;
         }
 
         private static string Extension(string path)


### PR DESCRIPTION
ProgramPaths now searches for files on a per-folder basis using a Queue instead of calling EnumerateFiles. This allows us to jump over permission errors.

Fixes #1779 