### PR TITLE
skip broken folder when re-index

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -222,6 +222,7 @@ namespace Wox.Plugin.Program.Programs
                         }
                         catch (DirectoryNotFoundException e)
                         {
+                            Log.Exception($"|Program.Win32.ProgramPaths|skip directory(<{currentDirectory}>)", e);
                             continue;
                         }
                     }

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -216,7 +216,14 @@ namespace Wox.Plugin.Program.Programs
                 {
                     foreach (var suffix in suffixes)
                     {
-                        files.AddRange(Directory.EnumerateFiles(currentDirectory, $"*.{suffix}", SearchOption.TopDirectoryOnly));
+                        try
+                        {
+                            files.AddRange(Directory.EnumerateFiles(currentDirectory, $"*.{suffix}", SearchOption.TopDirectoryOnly));
+                        }
+                        catch (DirectoryNotFoundException e)
+                        {
+                            continue;
+                        }
                     }
                 }
                 catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)


### PR DESCRIPTION
修复Windows下，因"找不到该项目"而导致的重新索引失败
fix #1975 