### PR TITLE
Fix mouse cursor unwanted automatic hover selection without moving it

### DIFF
--- a/Wox/ResultListBox.xaml
+++ b/Wox/ResultListBox.xaml
@@ -16,7 +16,8 @@
          KeyboardNavigation.DirectionalNavigation="Cycle" SelectionMode="Single"
          VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Standard"
          SelectionChanged="OnSelectionChanged"
-         IsSynchronizedWithCurrentItem="True">
+         IsSynchronizedWithCurrentItem="True"
+         PreviewMouseDown="ListBox_PreviewMouseDown">
     <!--IsSynchronizedWithCurrentItem: http://stackoverflow.com/a/7833798/2833083-->
     <ListBox.ItemTemplate>
         <DataTemplate>
@@ -65,6 +66,7 @@
     <ListBox.ItemContainerStyle>
         <Style TargetType="{x:Type ListBoxItem}">
             <EventSetter Event="MouseEnter" Handler="OnMouseEnter" />
+            <EventSetter Event="MouseMove" Handler="OnMouseMove" />
             <Setter Property="Height" Value="50" />
             <Setter Property="Margin" Value="0" />
             <Setter Property="Padding" Value="0" />

--- a/Wox/ResultListBox.xaml.cs
+++ b/Wox/ResultListBox.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Remoting.Contexts;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -7,6 +8,8 @@ namespace Wox
     [Synchronization]
     public partial class ResultListBox
     {
+        private Point _lastpos;
+        private ListBoxItem curItem = null;
         public ResultListBox()
         {
             InitializeComponent();
@@ -22,7 +25,26 @@ namespace Wox
 
         private void OnMouseEnter(object sender, MouseEventArgs e)
         {
-            ((ListBoxItem) sender).IsSelected = true;
+            curItem = (ListBoxItem)sender;
+            var p = e.GetPosition((IInputElement)sender);
+            _lastpos = p;
+        }
+
+        private void OnMouseMove(object sender, MouseEventArgs e)
+        {
+            var p = e.GetPosition((IInputElement)sender);
+            if (_lastpos != p)
+            {
+                ((ListBoxItem) sender).IsSelected = true;
+            }
+        }
+
+        private void ListBox_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (curItem != null)
+            {
+                curItem.IsSelected = true;
+            }
         }
     }
 }


### PR DESCRIPTION
This will fix issues #975 #1352 #1563 

Changes Explanation:

TL;DR
OnMouseEnter verifies if mouse's pos has changed
OnMouseMove updates selected item status
Bonus:
ListBox_PreviewMouseDown updates selected item status on mouse down (special scenarios).

Since MouseEnter triggers before MouseMove, I use the first to keep details about results item which is in mouse's cursor area, this will be useful later on ListBox Preview Mouse Down.
OnMouseMove will actually change the selected item status after a real mouse move has occurred.

However, it might occur that as soon as you relaunch (`ctrl`+`space`) Wox, and mouse's cursor area is pointing an item you want to click, since it is not moving and current selected item is the previous one but is not the one we are clicking, then ListBox_Preview_MouseDown will handle that scenario, using details saved on MouseEnter, i.e. selecting the item we want to click before actually Wox (MainWindow.xaml.cs) executes its mouse events handling.

