### PR TITLE
Extend the "Folder" plugin to enable open folder by PowerShell or Console

### DIFF
--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -128,7 +128,7 @@ namespace Wox.Plugin.Folder
             }
             else
             {
-                var result = op.GetResult(new DirectoryInfo(search));
+                var result = op.GetResult(new DirectoryInfo(search), true);
                 result.Score = 10000;
                 results.Add(result);
 
@@ -144,7 +144,7 @@ namespace Wox.Plugin.Folder
                 if (incompleteName.Length != 0 && !dir.Name.ToLower().StartsWith(incompleteName))
                     continue;
                 DirectoryInfo dirCopy = dir;
-                results.Add(op.GetResult(dirCopy));
+                results.Add(op.GetResult(dirCopy, false));
             }
 
             //Add children files

--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -110,10 +110,9 @@ namespace Wox.Plugin.Folder
                     search += "\\";
             }
 
-            string firstResult = "Open current directory";
             if (incompleteName.Length > 0)
             {
-                firstResult = "Open " + search;
+                var firstResult = "Open " + search;
 
                 results.Add(new Result
                 {

--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -91,7 +91,7 @@ namespace Wox.Plugin.Folder
                                     return false;
                                 }
                             }
-                            _context.API.ChangeQuery($"{query.ActionKeyword} {item.Path}{(item.Path.EndsWith("\\") ? "" : "\\")}");
+                            _context.API.ChangeQuery($"{query.ActionKeyword} {item.Path}{(item.Path.EndsWith("\\") ? "" : "\\")}{(datedFolder ? $"{today:yyyy-MM-dd}" : null)}");
                             return false;
                         },
                         ContextData = item,

--- a/Plugins/Wox.Plugin.Folder/Operators/CMDOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/CMDOperator.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Wox.Plugin.Folder.Operators
+{
+    class CMDOperator : IOperator
+    {
+        private readonly PluginInitContext _context;
+        private readonly Query _query;
+
+        public CMDOperator(PluginInitContext context, Query query, string actualSearch)
+        {
+            _context = context;
+            _query = query;
+            ActualSearch = actualSearch;
+        }
+
+        public string ActualSearch { get; }
+        public Result GetResult(FolderLink item)
+        {
+            return new Result
+            {
+                Title = item.Nickname,
+                IcoPath = item.Path,
+                SubTitle = "Ctrl + Enter to open the directory in Power Shell",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            var arg = $"\"{item.Path}\"";
+                            Process.Start("cmd.exe", arg);
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + item.Path);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {item.Path}{(item.Path.EndsWith("\\") ? "" : "\\")}");
+                    return false;
+                },
+                ContextData = item,
+            };
+        }
+
+        public Result GetResult(DirectoryInfo dir)
+        {
+            return new Result
+            {
+                Title = dir.Name,
+                IcoPath = dir.FullName,
+                SubTitle = "Ctrl + Enter to open the directory",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            var arg = $"\"{dir.FullName}\"";
+                            Process.Start("cmd.exe", arg);
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + dir.FullName);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    return false;
+                }
+            };
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.Folder/Operators/CMDOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/CMDOperator.cs
@@ -53,7 +53,7 @@ namespace Wox.Plugin.Folder.Operators
             };
         }
 
-        public Result GetResult(DirectoryInfo dir)
+        public Result GetResult(DirectoryInfo dir, bool openByEnter)
         {
             return new Result
             {
@@ -62,7 +62,7 @@ namespace Wox.Plugin.Folder.Operators
                 SubTitle = "Ctrl + Enter to open the directory",
                 Action = c =>
                 {
-                    if (c.SpecialKeyState.CtrlPressed)
+                    if (c.SpecialKeyState.CtrlPressed || openByEnter)
                     {
                         try
                         {
@@ -77,7 +77,7 @@ namespace Wox.Plugin.Folder.Operators
                         }
                     }
 
-                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}");
                     return false;
                 }
             };

--- a/Plugins/Wox.Plugin.Folder/Operators/CMDOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/CMDOperator.cs
@@ -28,14 +28,14 @@ namespace Wox.Plugin.Folder.Operators
             {
                 Title = item.Nickname,
                 IcoPath = item.Path,
-                SubTitle = "Ctrl + Enter to open the directory in Power Shell",
+                SubTitle = "Ctrl + Enter to open the directory in console",
                 Action = c =>
                 {
                     if (c.SpecialKeyState.CtrlPressed)
                     {
                         try
                         {
-                            var arg = $"\"{item.Path}\"";
+                            var arg = $"/k \"cd /d {item.Path}\"";
                             Process.Start("cmd.exe", arg);
                             return true;
                         }
@@ -66,7 +66,7 @@ namespace Wox.Plugin.Folder.Operators
                     {
                         try
                         {
-                            var arg = $"\"{dir.FullName}\"";
+                            var arg = $"/k \"cd /d {dir.FullName}\"";
                             Process.Start("cmd.exe", arg);
                             return true;
                         }

--- a/Plugins/Wox.Plugin.Folder/Operators/DatedOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/DatedOperator.cs
@@ -60,5 +60,34 @@ namespace Wox.Plugin.Folder.Operators
                 ContextData = item,
             };
         }
+
+        public Result GetResult(DirectoryInfo dir)
+        {
+            return new Result
+            {
+                Title = dir.Name,
+                IcoPath = dir.FullName,
+                SubTitle = "Ctrl + Enter to open the directory",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            Process.Start(dir.FullName);
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + dir.FullName);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    return false;
+                }
+            };
+        }
     }
 }

--- a/Plugins/Wox.Plugin.Folder/Operators/DatedOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/DatedOperator.cs
@@ -61,7 +61,7 @@ namespace Wox.Plugin.Folder.Operators
             };
         }
 
-        public Result GetResult(DirectoryInfo dir)
+        public Result GetResult(DirectoryInfo dir, bool openByEnter)
         {
             return new Result
             {
@@ -70,7 +70,7 @@ namespace Wox.Plugin.Folder.Operators
                 SubTitle = "Ctrl + Enter to open the directory",
                 Action = c =>
                 {
-                    if (c.SpecialKeyState.CtrlPressed)
+                    if (c.SpecialKeyState.CtrlPressed || openByEnter)
                     {
                         try
                         {
@@ -84,7 +84,7 @@ namespace Wox.Plugin.Folder.Operators
                         }
                     }
 
-                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}");
                     return false;
                 }
             };

--- a/Plugins/Wox.Plugin.Folder/Operators/DatedOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/DatedOperator.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Wox.Plugin.Folder.Operators
+{
+    class DatedOperator : IOperator
+    {
+        private readonly PluginInitContext _context;
+        private readonly Query _query;
+
+        public DatedOperator(PluginInitContext context, Query query, string actualSearch)
+        {
+            _context = context;
+            _query = query;
+            ActualSearch = actualSearch;
+        }
+
+        public string ActualSearch { get; }
+
+        public Result GetResult(FolderLink item)
+        {
+            var today = DateTime.Today;
+
+            return new Result
+            {
+                Title = $"{item.Nickname}\\{today:yyyy-MM-dd}",
+                IcoPath = item.Path,
+                SubTitle = "Ctrl + Enter to open the directory",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            if (Directory.Exists(item.Path))
+                            {
+                                var datedFolderPath = Path.Combine(item.Path, today.ToString("yyyy-MM-dd"));
+                                Directory.CreateDirectory(datedFolderPath);
+                                Process.Start(datedFolderPath);
+                            }
+
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + item.Path);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {item.Path}{(item.Path.EndsWith("\\") ? "" : "\\")}{today:yyyy-MM-dd}");
+                    return false;
+                },
+                ContextData = item,
+            };
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.Folder/Operators/DefaultOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/DefaultOperator.cs
@@ -51,5 +51,34 @@ namespace Wox.Plugin.Folder.Operators
                 ContextData = item,
             };
         }
+
+        public Result GetResult(DirectoryInfo dir)
+        {
+            return new Result
+            {
+                Title = dir.Name,
+                IcoPath = dir.FullName,
+                SubTitle = "Ctrl + Enter to open the directory",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            Process.Start(dir.FullName);
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + dir.FullName);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    return false;
+                }
+            };
+        }
     }
 }

--- a/Plugins/Wox.Plugin.Folder/Operators/DefaultOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/DefaultOperator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Wox.Plugin.Folder.Operators
+{
+    class DefaultOperator : IOperator
+    {
+        private readonly PluginInitContext _context;
+        private readonly Query _query;
+
+        public DefaultOperator(PluginInitContext context, Query query, string actualSearch)
+        {
+            _context = context;
+            _query = query;
+            ActualSearch = actualSearch;
+        }
+
+        public string ActualSearch { get; }
+        public Result GetResult(FolderLink item)
+        {
+            return new Result
+            {
+                Title = item.Nickname,
+                IcoPath = item.Path,
+                SubTitle = "Ctrl + Enter to open the directory",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            Process.Start(item.Path);
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + item.Path);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {item.Path}{(item.Path.EndsWith("\\") ? "" : "\\")}");
+                    return false;
+                },
+                ContextData = item,
+            };
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.Folder/Operators/DefaultOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/DefaultOperator.cs
@@ -52,7 +52,7 @@ namespace Wox.Plugin.Folder.Operators
             };
         }
 
-        public Result GetResult(DirectoryInfo dir)
+        public Result GetResult(DirectoryInfo dir, bool openByEnter)
         {
             return new Result
             {
@@ -61,7 +61,7 @@ namespace Wox.Plugin.Folder.Operators
                 SubTitle = "Ctrl + Enter to open the directory",
                 Action = c =>
                 {
-                    if (c.SpecialKeyState.CtrlPressed)
+                    if (c.SpecialKeyState.CtrlPressed || openByEnter)
                     {
                         try
                         {
@@ -75,7 +75,7 @@ namespace Wox.Plugin.Folder.Operators
                         }
                     }
 
-                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}");
                     return false;
                 }
             };

--- a/Plugins/Wox.Plugin.Folder/Operators/IOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/IOperator.cs
@@ -11,6 +11,6 @@ namespace Wox.Plugin.Folder.Operators
     {
         string ActualSearch { get; }
         Result GetResult(FolderLink item);
-        Result GetResult(DirectoryInfo dir);
+        Result GetResult(DirectoryInfo dir, bool openByEnter);
     }
 }

--- a/Plugins/Wox.Plugin.Folder/Operators/IOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/IOperator.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wox.Plugin.Folder.Operators
+{
+    interface IOperator
+    {
+        string ActualSearch { get; }
+        Result GetResult(FolderLink item);
+    }
+}

--- a/Plugins/Wox.Plugin.Folder/Operators/IOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/IOperator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,5 +11,6 @@ namespace Wox.Plugin.Folder.Operators
     {
         string ActualSearch { get; }
         Result GetResult(FolderLink item);
+        Result GetResult(DirectoryInfo dir);
     }
 }

--- a/Plugins/Wox.Plugin.Folder/Operators/OperatorFactory.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/OperatorFactory.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wox.Plugin.Folder.Operators
+{
+    class OperatorFactory
+    {
+        public static IOperator GetOperator(PluginInitContext context, Query query)
+        {
+            var search = query.Search.ToLower();
+            if (!string.IsNullOrEmpty(search))
+            {
+                var strs = search.Split('|');
+                var opSelector = strs.Length == 2 ? strs[1] : null;
+                var actualSearch = strs[0];
+                switch (opSelector)
+                {
+                    case "d":
+                        return new DatedOperator(context, query, actualSearch);
+                    case "ps":
+                        return new PSOperator(context, query, actualSearch);
+                }
+            }
+
+            return new DefaultOperator(context, query, search);
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.Folder/Operators/OperatorFactory.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/OperatorFactory.cs
@@ -22,6 +22,8 @@ namespace Wox.Plugin.Folder.Operators
                         return new DatedOperator(context, query, actualSearch);
                     case "ps":
                         return new PSOperator(context, query, actualSearch);
+                    case "cmd":
+                        return new CMDOperator(context, query, actualSearch);
                 }
             }
 

--- a/Plugins/Wox.Plugin.Folder/Operators/PSOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/PSOperator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -49,6 +50,36 @@ namespace Wox.Plugin.Folder.Operators
                     return false;
                 },
                 ContextData = item,
+            };
+        }
+
+        public Result GetResult(DirectoryInfo dir)
+        {
+            return new Result
+            {
+                Title = dir.Name,
+                IcoPath = dir.FullName,
+                SubTitle = "Ctrl + Enter to open the directory",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            var arg = $"-NoExit -Command \"Set-Location '{dir.FullName.Replace("\\", "\\\\")}'\"";
+                            Process.Start("powershell.exe", arg);
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + dir.FullName);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    return false;
+                }
             };
         }
     }

--- a/Plugins/Wox.Plugin.Folder/Operators/PSOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/PSOperator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Wox.Plugin.Folder.Operators
+{
+    class PSOperator : IOperator
+    {
+        private readonly PluginInitContext _context;
+        private readonly Query _query;
+
+        public PSOperator(PluginInitContext context, Query query, string actualSearch)
+        {
+            _context = context;
+            _query = query;
+            ActualSearch = actualSearch;
+        }
+
+        public string ActualSearch { get; }
+        public Result GetResult(FolderLink item)
+        {
+            return new Result
+            {
+                Title = item.Nickname,
+                IcoPath = item.Path,
+                SubTitle = "Ctrl + Enter to open the directory in Power Shell",
+                Action = c =>
+                {
+                    if (c.SpecialKeyState.CtrlPressed)
+                    {
+                        try
+                        {
+                            var arg = $"-NoExit -Command \"Set-Location '{item.Path.Replace("\\", "\\\\")}'\"";
+                            Process.Start("powershell.exe", arg);
+                            return true;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(ex.Message, "Could not start " + item.Path);
+                            return false;
+                        }
+                    }
+
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {item.Path}{(item.Path.EndsWith("\\") ? "" : "\\")}");
+                    return false;
+                },
+                ContextData = item,
+            };
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.Folder/Operators/PSOperator.cs
+++ b/Plugins/Wox.Plugin.Folder/Operators/PSOperator.cs
@@ -53,7 +53,7 @@ namespace Wox.Plugin.Folder.Operators
             };
         }
 
-        public Result GetResult(DirectoryInfo dir)
+        public Result GetResult(DirectoryInfo dir, bool openByEnter)
         {
             return new Result
             {
@@ -62,7 +62,7 @@ namespace Wox.Plugin.Folder.Operators
                 SubTitle = "Ctrl + Enter to open the directory",
                 Action = c =>
                 {
-                    if (c.SpecialKeyState.CtrlPressed)
+                    if (c.SpecialKeyState.CtrlPressed || openByEnter)
                     {
                         try
                         {
@@ -77,7 +77,7 @@ namespace Wox.Plugin.Folder.Operators
                         }
                     }
 
-                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}\\");
+                    _context.API.ChangeQuery($"{_query.ActionKeyword} {dir.FullName}");
                     return false;
                 }
             };

--- a/Plugins/Wox.Plugin.Folder/Wox.Plugin.Folder.csproj
+++ b/Plugins/Wox.Plugin.Folder/Wox.Plugin.Folder.csproj
@@ -63,6 +63,11 @@
     <Compile Include="FolderPluginSettings.xaml.cs">
       <DependentUpon>FolderPluginSettings.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Operators\DatedOperator.cs" />
+    <Compile Include="Operators\DefaultOperator.cs" />
+    <Compile Include="Operators\IOperator.cs" />
+    <Compile Include="Operators\OperatorFactory.cs" />
+    <Compile Include="Operators\PSOperator.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Plugins/Wox.Plugin.Folder/Wox.Plugin.Folder.csproj
+++ b/Plugins/Wox.Plugin.Folder/Wox.Plugin.Folder.csproj
@@ -63,6 +63,7 @@
     <Compile Include="FolderPluginSettings.xaml.cs">
       <DependentUpon>FolderPluginSettings.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Operators\CMDOperator.cs" />
     <Compile Include="Operators\DatedOperator.cs" />
     <Compile Include="Operators\DefaultOperator.cs" />
     <Compile Include="Operators\IOperator.cs" />


### PR DESCRIPTION
Added 3 feature to the folder plugin, by adding an operator following the search query:

1. Automatic create a dated folder, would be useful for organize temporary working folder.
For example, search "Temp|d" will create/open Temp\yyyy-MM-dd as today's working folder.

2. Open the folder by Power Shell
Query "MyProject|ps"

3. Open the folder by command line console
Query "MyFolder|cmd"
