### PR TITLE
Feature/fix file not found

### DIFF
--- a/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/Plugins/Wox.Plugin.Shell/Main.cs
@@ -239,7 +239,7 @@ namespace Wox.Plugin.Shell
                 _settings.AddCmdHistory(command);
             }
             catch (Exception e) when (e is FileNotFoundException
-                                      // Can't fine file specified, can't find file specified. As per https://msdn.microsoft.com/en-us/library/cc231199.aspx
+                                      // Can't find file specified, can't find file specified. As per https://msdn.microsoft.com/en-us/library/cc231199.aspx
                                       || e is Win32Exception w32e && (w32e.NativeErrorCode == 0x00000002 || w32e.NativeErrorCode == 0x00000003))
             {
                 MessageBox.Show($"Command not found: {e.Message}");

--- a/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/Plugins/Wox.Plugin.Shell/Main.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -237,7 +238,9 @@ namespace Wox.Plugin.Shell
                 Process.Start(info);
                 _settings.AddCmdHistory(command);
             }
-            catch (FileNotFoundException e)
+            catch (Exception e) when (e is FileNotFoundException
+                                      // Can't fine file specified, can't find file specified. As per https://msdn.microsoft.com/en-us/library/cc231199.aspx
+                                      || e is Win32Exception w32e && (w32e.NativeErrorCode == 0x00000002 || w32e.NativeErrorCode == 0x00000003))
             {
                 MessageBox.Show($"Command not found: {e.Message}");
             }


### PR DESCRIPTION
### Problem description

Whenever entering an invalid command (that was neither found directly or exists in the path), the application is supposed to show an error message ("Command not found:") but errors out completely.

This fix extends the catch block to handle these errors correctly

### Steps to reproduce

- Wox with the Shell plugin activated, set to replace Win+R
- Run an invalid command, such as "sdfdsfsdfsdfsdfs"

### Expected results

A message box is shown that this command is not found

### Actual results

A huge error message is shown, assuming that there was a problem with Wox, not with the user input