### PR TITLE
Link F1 help to current website

### DIFF
--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -128,7 +128,7 @@ namespace Wox.ViewModel
 
             StartHelpCommand = new RelayCommand(_ =>
             {
-                Process.Start("http://doc.getwox.com");
+                Process.Start("http://doc.wox.one/");
             });
 
             OpenResultCommand = new RelayCommand(index =>


### PR DESCRIPTION
Pressing F1 leads to the - now unavailable - old wox website.

The updated URL should be http://doc.wox.one/

#2413