### PR TITLE
enable portable mode

### DIFF
--- a/Wox.Infrastructure/Logger/Log.cs
+++ b/Wox.Infrastructure/Logger/Log.cs
@@ -22,8 +22,7 @@ namespace Wox.Infrastructure.Logger
             var configuration = new LoggingConfiguration();
             var target = new FileTarget();
             configuration.AddTarget("file", target);
-            target.FileName = "${specialfolder:folder=ApplicationData}/" + Constant.Wox + "/" + DirectoryName + "/" +
-                              Constant.Version + "/${shortdate}.txt";
+            target.FileName = path.Replace(@"\", "/") + "/${shortdate}.txt";
 #if DEBUG
             var rule = new LoggingRule("*", LogLevel.Debug, target);
 #else
@@ -105,7 +104,7 @@ namespace Wox.Infrastructure.Logger
             }
 #endif
         }
-        
+
         /// <param name="message">example: "|prefix|unprefixed" </param>
         public static void Debug(string message)
         {

--- a/Wox.Infrastructure/Wox.cs
+++ b/Wox.Infrastructure/Wox.cs
@@ -7,13 +7,29 @@ namespace Wox.Infrastructure
 {
     public static class Constant
     {
+
+        public static string DetermineDataDirectory()
+        {
+            // use the method of VSCode to enable portable mode
+            // https://code.visualstudio.com/docs/editor/portable
+            string portableDataPath = Path.Combine(ProgramDirectory, "data");
+            if (Directory.Exists(portableDataPath))
+            {
+                return portableDataPath;
+            }
+            else
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Wox);
+            }
+        }
+
         public const string Wox = "Wox";
         public const string Plugins = "Plugins";
 
         private static readonly Assembly Assembly = Assembly.GetExecutingAssembly();
         public static readonly string ProgramDirectory = Directory.GetParent(Assembly.Location.NonNull()).ToString();
         public static readonly string ExecutablePath = Path.Combine(ProgramDirectory, Wox + ".exe");
-        public static readonly string DataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Wox);
+        public static readonly string DataDirectory = DetermineDataDirectory();
         public static readonly string PluginsDirectory = Path.Combine(DataDirectory, Plugins);
         public static readonly string PreinstalledDirectory = Path.Combine(ProgramDirectory, Plugins);
         public const string Repository = "https://github.com/Wox-launcher/Wox";


### PR DESCRIPTION
#629 
Enable portable mode by using relative directory.

The portable mode works like that of VSCode https://code.visualstudio.com/docs/editor/portable

If there is a folder named "data" nearby the "wox.exe", it will be used to store the application data, otherwise it will use the default "AppData".