### PR TITLE
Fix missing comma in list of available languages

### DIFF
--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -41,9 +41,9 @@ namespace Wox.Core.Resource
                 Korean,
                 Serbian,
                 Portuguese_BR,
-		Italian,
+		        Italian,
                 Norwegian_Bokmal,
-		Slovak
+		        Slovak,
 		        Espanol
             };
             return languages;


### PR DESCRIPTION
A comma was missing in the list of available languages which led the build to fail.