### PR TITLE
Add plugin option `KeepResultOrder` to disable result sorting on score

### DIFF
--- a/Plugins/Wox.Plugin.Sys/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Sys/Languages/en.xaml
@@ -1,9 +1,17 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
-
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
     <system:String x:Key="wox_plugin_sys_command">Command</system:String>
     <system:String x:Key="wox_plugin_sys_desc">Description</system:String>
+
+    <system:String x:Key="wox_plugin_sys_shutdown_computer_command">Shutdown</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_computer_command">Restart</system:String>
+    <system:String x:Key="wox_plugin_sys_log_off_command">Log off</system:String>
+    <system:String x:Key="wox_plugin_sys_lock_command">Lock</system:String>
+    <system:String x:Key="wox_plugin_sys_exit_command">Exit</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_command">Restart Wox</system:String>
+    <system:String x:Key="wox_plugin_sys_setting_command">Settings</system:String>
+    <system:String x:Key="wox_plugin_sys_sleep_command">Sleep</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate_command">Hibernate</system:String>
+    <system:String x:Key="wox_plugin_sys_emptyrecyclebin_command">Empty Recycle Bin</system:String>
 
     <system:String x:Key="wox_plugin_sys_shutdown_computer">Shutdown Computer</system:String>
     <system:String x:Key="wox_plugin_sys_restart_computer">Restart Computer</system:String>
@@ -13,7 +21,11 @@
     <system:String x:Key="wox_plugin_sys_restart">Restart Wox</system:String>
     <system:String x:Key="wox_plugin_sys_setting">Tweak this app</system:String>
     <system:String x:Key="wox_plugin_sys_sleep">Put computer to sleep</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate">Hibernate computer</system:String>
     <system:String x:Key="wox_plugin_sys_emptyrecyclebin">Empty recycle bin</system:String>
+
+    <system:String x:Key="wox_plugin_sys_confirm_shutdown">Are you sure you want to shut the computer down?</system:String>
+    <system:String x:Key="wox_plugin_sys_confirm_restart">Are you sure you want to restart the computer?</system:String>
 
     <system:String x:Key="wox_plugin_sys_plugin_name">System Commands</system:String>
     <system:String x:Key="wox_plugin_sys_plugin_description">Provides System related commands. e.g. shutdown, lock, settings etc.</system:String>

--- a/Plugins/Wox.Plugin.Sys/Languages/es.xaml
+++ b/Plugins/Wox.Plugin.Sys/Languages/es.xaml
@@ -1,0 +1,33 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <system:String x:Key="wox_plugin_sys_command">Comando</system:String>
+    <system:String x:Key="wox_plugin_sys_desc">Descripción</system:String>
+
+    <system:String x:Key="wox_plugin_sys_shutdown_computer_command">Apagar</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_computer_command">Reiniciar</system:String>
+    <system:String x:Key="wox_plugin_sys_log_off_command">Desconectarse</system:String>
+    <system:String x:Key="wox_plugin_sys_lock_command">Bloquear</system:String>
+    <system:String x:Key="wox_plugin_sys_exit_command">Salida</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_command">Reiniciar Wox</system:String>
+    <system:String x:Key="wox_plugin_sys_setting_command">Ajustes</system:String>
+    <system:String x:Key="wox_plugin_sys_sleep_command">Suspender</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate_command">Hibernar</system:String>
+    <system:String x:Key="wox_plugin_sys_emptyrecyclebin_command">Vaciar papelera de reciclaje</system:String>
+
+    <system:String x:Key="wox_plugin_sys_shutdown_computer">Apagar la computadora</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_computer">Reiniciar la computadora</system:String>
+    <system:String x:Key="wox_plugin_sys_log_off">Cerrar sesión</system:String>
+    <system:String x:Key="wox_plugin_sys_lock">Bloquea ésta computadora</system:String>
+    <system:String x:Key="wox_plugin_sys_exit">Cerrar wox</system:String>
+    <system:String x:Key="wox_plugin_sys_restart">Reiniciar wox</system:String>
+    <system:String x:Key="wox_plugin_sys_setting">Configurar esta aplicación</system:String>
+    <system:String x:Key="wox_plugin_sys_sleep">Suspende el ordenador</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate">Hibernar ordenador</system:String>
+    <system:String x:Key="wox_plugin_sys_emptyrecyclebin">Vaciar papelera de reciclaje</system:String>
+
+    <system:String x:Key="wox_plugin_sys_confirm_shutdown">¿Estás seguro de que quieres apagar el ordenador?</system:String>
+    <system:String x:Key="wox_plugin_sys_confirm_restart">¿Estás seguro de que deseas reiniciar el ordenador?</system:String>
+
+    <system:String x:Key="wox_plugin_sys_plugin_name">Comandos del sistema</system:String>
+    <system:String x:Key="wox_plugin_sys_plugin_description">Proporciona comandos relacionados con el sistema.  p.ej.  apagado, bloqueo, ajustes etc.</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -80,14 +80,14 @@ namespace Wox.Plugin.Sys
             {
                 new Result
                 {
-                    Title = "Shutdown",
+                    Title = context.API.GetTranslation("wox_plugin_sys_shutdown_computer_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_shutdown_computer"),
                     IcoPath = "Images\\shutdown.png",
                     Action = c =>
                     {
-                        var reuslt = MessageBox.Show("Are you sure you want to shut the computer down?",
+                        var result = MessageBox.Show(context.API.GetTranslation("wox_plugin_sys_confirm_shutdown"),
                                                      "Shutdown Computer?", MessageBoxButton.YesNo, MessageBoxImage.Warning);
-                        if (reuslt == MessageBoxResult.Yes)
+                        if (result == MessageBoxResult.Yes)
                         {
                             Process.Start("shutdown", "/s /t 0");
                         }
@@ -96,12 +96,12 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Restart",
+                    Title = context.API.GetTranslation("wox_plugin_sys_restart_computer_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_restart_computer"),
                     IcoPath = "Images\\restart.png",
                     Action = c =>
                     {
-                        var result = MessageBox.Show("Are you sure you want to restart the computer?",
+                        var result = MessageBox.Show(context.API.GetTranslation("wox_plugin_sys_confirm_restart"),
                                                      "Restart Computer?", MessageBoxButton.YesNo, MessageBoxImage.Warning);
                         if (result == MessageBoxResult.Yes)
                         {
@@ -112,14 +112,14 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Log off",
+                    Title = context.API.GetTranslation("wox_plugin_sys_log_off_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_log_off"),
                     IcoPath = "Images\\logoff.png",
                     Action = c => ExitWindowsEx(EWX_LOGOFF, 0)
                 },
                 new Result
                 {
-                    Title = "Lock",
+                    Title = context.API.GetTranslation("wox_plugin_sys_lock_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_lock"),
                     IcoPath = "Images\\lock.png",
                     Action = c =>
@@ -130,14 +130,21 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Sleep",
+                    Title = context.API.GetTranslation("wox_plugin_sys_sleep_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_sleep"),
                     IcoPath = "Images\\sleep.png",
                     Action = c => FormsApplication.SetSuspendState(PowerState.Suspend, false, false)
                 },
                 new Result
                 {
-                    Title = "Empty Recycle Bin",
+                    Title = context.API.GetTranslation("wox_plugin_sys_hibernate_command"),
+                    SubTitle = context.API.GetTranslation("wox_plugin_sys_hibernate"),
+                    IcoPath = "Images\\sleep.png", // Icon change needed
+                    Action = c => FormsApplication.SetSuspendState(PowerState.Hibernate, false, false)
+                },
+                new Result
+                {
+                    Title = context.API.GetTranslation("wox_plugin_sys_emptyrecyclebin_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_emptyrecyclebin"),
                     IcoPath = "Images\\recyclebin.png",
                     Action = c =>
@@ -158,7 +165,7 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Exit",
+                    Title = context.API.GetTranslation("wox_plugin_sys_exit_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_exit"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
@@ -169,7 +176,7 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Restart Wox",
+                    Title = context.API.GetTranslation("wox_plugin_sys_restart_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_restart"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
@@ -180,7 +187,7 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Settings",
+                    Title = context.API.GetTranslation("wox_plugin_sys_setting_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_setting"),
                     IcoPath = "Images\\app.png",
                     Action = c =>

--- a/Plugins/Wox.Plugin.Sys/Wox.Plugin.Sys.csproj
+++ b/Plugins/Wox.Plugin.Sys/Wox.Plugin.Sys.csproj
@@ -102,6 +102,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Languages\es.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Page Include="SysSettings.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -21,6 +21,7 @@ namespace Wox.Core.Resource
 	public static Language Italian = new Language("it", "Italiano");
         public static Language Norwegian_Bokmal = new Language("nb-NO", "Norsk Bokmål");
         public static Language Slovak = new Language("sk", "Slovenský");
+        public static Language Espanol = new Language("es", "Español");
 
         public static List<Language> GetAvailableLanguages()
         {
@@ -43,6 +44,7 @@ namespace Wox.Core.Resource
 		Italian,
                 Norwegian_Bokmal,
 		Slovak
+		        Espanol
             };
             return languages;
         }

--- a/Wox.Plugin/PluginMetadata.cs
+++ b/Wox.Plugin/PluginMetadata.cs
@@ -38,6 +38,8 @@ namespace Wox.Plugin
 
         public string IcoPath { get; set;}
 
+        public bool KeepResultOrder { get; set; }
+
         public override string ToString()
         {
             return Name;

--- a/Wox/Languages/es.xaml
+++ b/Wox/Languages/es.xaml
@@ -1,0 +1,129 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+  <!--MainWindow-->
+  <system:String x:Key="registerHotkeyFailed">Error al registrar la tecla de acceso rápido: {0}</system:String>
+  <system:String x:Key="couldnotStartCmd">No se pudo iniciar {0}</system:String>
+  <system:String x:Key="invalidWoxPluginFileFormat">Formato de archivo de plugin Wox no válido</system:String>
+  <system:String x:Key="setAsTopMostInThisQuery">Establecer como máximo en esta consulta</system:String>
+  <system:String x:Key="cancelTopMostInThisQuery">Cancelar más arriba en esta consulta</system:String>
+  <system:String x:Key="executeQuery">Consulta de ejecución: {0}</system:String>
+  <system:String x:Key="lastExecuteTime">Último tiempo de ejecución: {0}</system:String>
+  <system:String x:Key="iconTrayOpen">Abrir</system:String>
+  <system:String x:Key="iconTraySettings">Ajustes</system:String>
+  <system:String x:Key="iconTrayAbout">Acerca de</system:String>
+  <system:String x:Key="iconTrayExit">Salir</system:String>
+  <!--Setting General-->
+  <system:String x:Key="wox_settings">Configuraciones Wox</system:String>
+  <system:String x:Key="general">General</system:String>
+  <system:String x:Key="startWoxOnSystemStartup">Iniciar Wox en el inicio del sistema</system:String>
+  <system:String x:Key="hideWoxWhenLoseFocus">Ocultar Wox cuando se pierde el enfoque</system:String>
+  <system:String x:Key="dontPromptUpdateMsg">No mostrar notificaciones de nuevas versiones.</system:String>
+  <system:String x:Key="rememberLastLocation">Recuerde la última ubicación de lanzamiento</system:String>
+  <system:String x:Key="language">Idioma</system:String>
+  <system:String x:Key="lastQueryMode">Último estilo de consulta</system:String>
+  <system:String x:Key="LastQueryPreserved">Preservar la última consulta</system:String>
+  <system:String x:Key="LastQuerySelected">Seleccione la última consulta</system:String>
+  <system:String x:Key="LastQueryEmpty">Vaciar última consulta</system:String>
+  <system:String x:Key="maxShowResults">Máximos resultados mostrados</system:String>
+  <system:String x:Key="ignoreHotkeysOnFullscreen">Ignorar teclas de acceso rápido en modo de pantalla completa</system:String>
+  <system:String x:Key="pythonDirectory">Directorio de Python</system:String>
+  <system:String x:Key="autoUpdates">Auto actualización</system:String>
+  <system:String x:Key="selectPythonDirectory">Seleccionar</system:String>
+  <system:String x:Key="hideOnStartup">Ocultar Wox en el inicio</system:String>
+  <system:String x:Key="hideNotifyIcon">Ocultar icono de bandeja</system:String>
+  <!--Setting Plugin-->
+  <system:String x:Key="plugin">Plugins</system:String>
+  <system:String x:Key="browserMorePlugins">Encuentra más complementos</system:String>
+  <system:String x:Key="disable">Inhabilitar</system:String>
+  <system:String x:Key="actionKeywords">Palabras clave de acción</system:String>
+  <system:String x:Key="pluginDirectory">Directorio de complementos</system:String>
+  <system:String x:Key="author">Autor</system:String>
+  <system:String x:Key="plugin_init_time">Tiempo de inicio: {0} ms</system:String>
+  <system:String x:Key="plugin_query_time">Tiempo de consulta: {0} ms</system:String>
+  <!--Setting Theme-->
+  <system:String x:Key="theme">Tema</system:String>
+  <system:String x:Key="browserMoreThemes">Navegar por más temas</system:String>
+  <system:String x:Key="helloWox">Hola wox</system:String>
+  <system:String x:Key="queryBoxFont">Fuente de consulta</system:String>
+  <system:String x:Key="resultItemFont">Fuente de elemento de resultado</system:String>
+  <system:String x:Key="windowMode">Modo ventana</system:String>
+  <system:String x:Key="opacity">Opacidad</system:String>
+  <system:String x:Key="theme_load_failure_path_not_exists">El tema {0} no existe, retrocede al tema predeterminado</system:String>
+  <system:String x:Key="theme_load_failure_parse_error">Error al cargar el tema {0}, retroceso al tema predeterminado</system:String>
+  <!--Setting Hotkey-->
+  <system:String x:Key="hotkey">Tecla de acceso directo</system:String>
+  <system:String x:Key="woxHotkey">Wox Hotkey</system:String>
+  <system:String x:Key="customQueryHotkey">Tecla rápida de consulta personalizada</system:String>
+  <system:String x:Key="delete">Borrar</system:String>
+  <system:String x:Key="edit">Editar</system:String>
+  <system:String x:Key="add">Añadir</system:String>
+  <system:String x:Key="pleaseSelectAnItem">Por favor seleccione un artículo</system:String>
+  <system:String x:Key="deleteCustomHotkeyWarning">¿Está seguro de que desea eliminar la tecla de acceso directo del complemento {0}?</system:String>
+  <!--Setting Proxy-->
+  <system:String x:Key="proxy">Proxy HTTP</system:String>
+  <system:String x:Key="enableProxy">Habilitar proxy HTTP</system:String>
+  <system:String x:Key="server">Servidor HTTP</system:String>
+  <system:String x:Key="port">Puerto</system:String>
+  <system:String x:Key="userName">Nombre de usuario</system:String>
+  <system:String x:Key="password">Contraseña</system:String>
+  <system:String x:Key="testProxy">Proxy de prueba</system:String>
+  <system:String x:Key="save">Salvar</system:String>
+  <system:String x:Key="serverCantBeEmpty">El campo del servidor no puede estar vacío</system:String>
+  <system:String x:Key="portCantBeEmpty">El campo del puerto no puede estar vacío</system:String>
+  <system:String x:Key="invalidPortFormat">Formato de puerto no válido</system:String>
+  <system:String x:Key="saveProxySuccessfully">Configuración de proxy guardada correctamente</system:String>
+  <system:String x:Key="proxyIsCorrect">Proxy configurado correctamente</system:String>
+  <system:String x:Key="proxyConnectFailed">Falló la conexión proxy</system:String>
+  <!--Setting About-->
+  <system:String x:Key="about">Acerca de</system:String>
+  <system:String x:Key="website">Sitio web</system:String>
+  <system:String x:Key="version">Versión</system:String>
+  <system:String x:Key="about_activate_times">Has activado Wox {0} veces.</system:String>
+  <system:String x:Key="checkUpdates">Buscar actualizaciones</system:String>
+  <system:String x:Key="newVersionTips">La nueva versión {0} está disponible, reinicia Wox.</system:String>
+  <system:String x:Key="checkUpdatesFailed">Las actualizaciones de verificación fallaron, verifique su conexión y la configuración del proxy en api.github.com.</system:String>
+  <system:String x:Key="downloadUpdatesFailed">
+Error al descargar las actualizaciones, verifique su conexión y la configuración del proxy en github-cloud.s3.amazonaws.com, o vaya a https://github.com/Wox-launcher/Wox/releases para descargar las actualizaciones manualmente.
+    </system:String>
+  <system:String x:Key="releaseNotes">Notas de lanzamiento:</system:String>
+  <!--Action Keyword Setting Dialog-->
+  <system:String x:Key="oldActionKeywords">Palabra clave de acción antigua</system:String>
+  <system:String x:Key="newActionKeywords">Nueva palabra clave de acción</system:String>
+  <system:String x:Key="cancel">Cancelar</system:String>
+  <system:String x:Key="done">Hecho</system:String>
+  <system:String x:Key="cannotFindSpecifiedPlugin">No puedo encontrar el plugin especificado</system:String>
+  <system:String x:Key="newActionKeywordsCannotBeEmpty">La nueva palabra clave de acción no puede estar vacía</system:String>
+  <system:String x:Key="newActionKeywordsHasBeenAssigned">Se han asignado nuevas palabras clave de acción a otro complemento, asigne otra palabra clave de acción nueva</system:String>
+  <system:String x:Key="succeed">Listo!</system:String>
+  <system:String x:Key="actionkeyword_tips">Utilice * si no desea especificar una palabra clave de acción</system:String>
+  <!--Custom Query Hotkey Dialog-->
+  <system:String x:Key="preview">Avance</system:String>
+  <system:String x:Key="hotkeyIsNotUnavailable">La tecla de acceso directo no está disponible, seleccione una nueva tecla de acceso rápido</system:String>
+  <system:String x:Key="invalidPluginHotkey">Tecla de acceso directo no válida</system:String>
+  <system:String x:Key="update">Actualizar</system:String>
+  <!--Hotkey Control-->
+  <system:String x:Key="hotkeyUnavailable">Hotkey no disponible</system:String>
+  <!--Crash Reporter-->
+  <system:String x:Key="reportWindow_version">Versión</system:String>
+  <system:String x:Key="reportWindow_time">Hora</system:String>
+  <system:String x:Key="reportWindow_reproduce">Por favor díganos cómo se bloqueó la aplicación para que podamos solucionarlo</system:String>
+  <system:String x:Key="reportWindow_send_report">Enviar reporte</system:String>
+  <system:String x:Key="reportWindow_cancel">Cancelar</system:String>
+  <system:String x:Key="reportWindow_general">General</system:String>
+  <system:String x:Key="reportWindow_exceptions">Excepciones</system:String>
+  <system:String x:Key="reportWindow_exception_type">Tipo de excepción</system:String>
+  <system:String x:Key="reportWindow_source">Fuente</system:String>
+  <system:String x:Key="reportWindow_stack_trace">Stack trace</system:String>
+  <system:String x:Key="reportWindow_sending">Enviando</system:String>
+  <system:String x:Key="reportWindow_report_succeed">Informe enviado correctamente</system:String>
+  <system:String x:Key="reportWindow_report_failed">Error al enviar el informe</system:String>
+  <system:String x:Key="reportWindow_wox_got_an_error">Wox tiene un error</system:String>
+  <!--update-->
+  <system:String x:Key="update_wox_update_new_version_available">La nueva versión de Wox {0} ya está disponible</system:String>
+  <system:String x:Key="update_wox_update_error">Se ha producido un error al intentar instalar actualizaciones de software.</system:String>
+  <system:String x:Key="update_wox_update">Actualizar</system:String>
+  <system:String x:Key="update_wox_update_cancel">Cancelar</system:String>
+  <system:String x:Key="update_wox_update_restart_wox_tip">Esta actualización reiniciará Wox</system:String>
+  <system:String x:Key="update_wox_update_upadte_files">Los siguientes archivos serán actualizados</system:String>
+  <system:String x:Key="update_wox_update_files">Actualizar archivos</system:String>
+  <system:String x:Key="update_wox_update_upadte_description">Actualización de la descripción</system:String>
+</ResourceDictionary>

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -138,7 +138,7 @@
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="{Binding PluginPair.Metadata.Name}"
-                                               ToolTip="{Binding PluginPair.Metadata.Name}"
+                                               ToolTip="{Binding PluginPair.Metadata.Version}"
                                                Grid.Column="0"
                                                Cursor="Hand" MouseUp="OnPluginNameClick" FontSize="24"
                                                HorizontalAlignment="Left" />

--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -641,7 +641,7 @@ namespace Wox.ViewModel
 
             if (originQuery.RawQuery == _lastQuery.RawQuery)
             {
-                Results.AddResults(list, metadata.ID);
+                Results.AddResults(list, metadata.ID, metadata.KeepResultOrder);
             }
 
             if (Results.Visbility != Visibility.Visible && list.Count > 0)

--- a/Wox/ViewModel/ResultsViewModel.cs
+++ b/Wox/ViewModel/ResultsViewModel.cs
@@ -125,11 +125,11 @@ namespace Wox.ViewModel
         /// <summary>
         /// To avoid deadlock, this method should not called from main thread
         /// </summary>
-        public void AddResults(List<Result> newRawResults, string resultId)
+        public void AddResults(List<Result> newRawResults, string resultId, bool keepOrder = false)
         {
             lock (_addResultsLock)
             {
-                var newResults = NewResults(newRawResults, resultId);
+                var newResults = NewResults(newRawResults, resultId, keepOrder);
 
                 // update UI in one run, so it can avoid UI flickering
                 Results.Update(newResults);
@@ -146,9 +146,12 @@ namespace Wox.ViewModel
             }
         }
 
-        private List<ResultViewModel> NewResults(List<Result> newRawResults, string resultId)
+        private List<ResultViewModel> NewResults(List<Result> newRawResults, string resultId, bool keepOrder)
         {
             var newResults = newRawResults.Select(r => new ResultViewModel(r)).ToList();
+            if (keepOrder)
+                return newResults;
+
             var results = Results.ToList();
             var oldResults = results.Where(r => r.Result.PluginID == resultId).ToList();
 

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -313,6 +313,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Languages\es.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
Issue: https://github.com/Wox-launcher/Wox/issues/1911, https://github.com/Wox-launcher/Wox/issues/1583

some plugins (e.g. Clipboard History) need to control result order, there should be an option for this.