### PR TITLE
Fix post-build script requiring setting execution policy on local user environment

### DIFF
--- a/Plugins/Wox.Plugin.Everything/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Everything/Languages/en.xaml
@@ -9,6 +9,10 @@
     <system:String x:Key="wox_plugin_everything_open_containing_folder">Open parent folder</system:String>
     <system:String x:Key="wox_plugin_everything_open_with_editor">Open with {0}</system:String>
     <system:String x:Key="wox_plugin_everything_editor_path">Editor Path</system:String>
+    <system:String x:Key="wox_plugin_everything_copy_path">Copy path</system:String>
+    <system:String x:Key="wox_plugin_everything_copy">Copy</system:String>
+    <system:String x:Key="wox_plugin_everything_delete">Delete</system:String>
+    <system:String x:Key="wox_plugin_everything_canot_delete">Can't delete {0}</system:String>
     
     <system:String x:Key="wox_plugin_everything_plugin_name">Everything</system:String>
     <system:String x:Key="wox_plugin_everything_plugin_description">Search on-disk files using Everything</system:String>

--- a/Plugins/Wox.Plugin.Everything/Languages/zh-cn.xaml
+++ b/Plugins/Wox.Plugin.Everything/Languages/zh-cn.xaml
@@ -9,6 +9,10 @@
     <system:String x:Key="wox_plugin_everything_open_containing_folder">打开所属文件夹</system:String>
     <system:String x:Key="wox_plugin_everything_open_with_editor">使用{0}打开</system:String>
     <system:String x:Key="wox_plugin_everything_editor_path">编辑器路径</system:String>
+    <system:String x:Key="wox_plugin_everything_copy_path">拷贝路径</system:String>
+    <system:String x:Key="wox_plugin_everything_copy">拷贝</system:String>
+    <system:String x:Key="wox_plugin_everything_delete">删除</system:String>
+    <system:String x:Key="wox_plugin_everything_canot_delete">无法删除 {0}</system:String>
     
     <system:String x:Key="wox_plugin_everything_plugin_name">Everything</system:String>
     <system:String x:Key="wox_plugin_everything_plugin_description">利用 Everything 搜索磁盘文件</system:String>

--- a/Plugins/Wox.Plugin.Everything/Main.cs
+++ b/Plugins/Wox.Plugin.Everything/Main.cs
@@ -211,6 +211,53 @@ namespace Wox.Plugin.Everything
                 }
             }
 
+            var icoPath = (record.Type == ResultType.File) ? "Images\\file.png" : "Images\\folder.png";
+            contextMenus.Add(new Result
+            {
+                Title = _context.API.GetTranslation("wox_plugin_everything_copy_path"),
+                Action = (context) =>
+                {
+                    Clipboard.SetText(record.FullPath);
+                    return true;
+                },
+                IcoPath = icoPath
+            });
+
+            contextMenus.Add(new Result
+            {
+                Title = _context.API.GetTranslation("wox_plugin_everything_copy"),
+                Action = (context) =>
+                {
+                    Clipboard.SetFileDropList(new System.Collections.Specialized.StringCollection { record.FullPath });
+                    return true;
+                },
+                IcoPath = icoPath
+            });
+
+            if (record.Type == ResultType.File || record.Type == ResultType.Folder)
+                contextMenus.Add(new Result
+                {
+                    Title = _context.API.GetTranslation("wox_plugin_everything_delete"),
+                    Action = (context) =>
+                    {
+                        try
+                        {
+                            if (record.Type == ResultType.File)
+                                System.IO.File.Delete(record.FullPath);
+                            else
+                                System.IO.Directory.Delete(record.FullPath);
+                        }
+                        catch
+                        {
+                            _context.API.ShowMsg(string.Format(_context.API.GetTranslation("wox_plugin_everything_canot_delete"), record.FullPath), string.Empty, string.Empty);
+                            return false;
+                        }
+
+                        return true;
+                    },
+                    IcoPath = icoPath
+                });
+
             return contextMenus;
         }
 

--- a/Plugins/Wox.Plugin.Folder/FolderLink.cs
+++ b/Plugins/Wox.Plugin.Folder/FolderLink.cs
@@ -10,9 +10,9 @@ namespace Wox.Plugin.Folder
         [JsonProperty]
         public string Path { get; set; }
 
-        public string Nickname
-        {
-            get { return Path.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None).Last(); }
-        }
+        public string Nickname =>
+           Path.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None)
+               .Last()
+           + " (" + System.IO.Path.GetDirectoryName(Path) + ")";
     }
 }

--- a/Plugins/Wox.Plugin.Folder/FolderLink.cs
+++ b/Plugins/Wox.Plugin.Folder/FolderLink.cs
@@ -10,9 +10,9 @@ namespace Wox.Plugin.Folder
         [JsonProperty]
         public string Path { get; set; }
 
-        public string Nickname =>
-           Path.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None)
-               .Last()
-           + " (" + System.IO.Path.GetDirectoryName(Path) + ")";
+        public string Nickname
+        {
+            get { return Path.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None).Last(); }
+        }
     }
 }

--- a/Plugins/Wox.Plugin.Sys/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Sys/Languages/en.xaml
@@ -1,9 +1,17 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
-
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
     <system:String x:Key="wox_plugin_sys_command">Command</system:String>
     <system:String x:Key="wox_plugin_sys_desc">Description</system:String>
+
+    <system:String x:Key="wox_plugin_sys_shutdown_computer_command">Shutdown</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_computer_command">Restart</system:String>
+    <system:String x:Key="wox_plugin_sys_log_off_command">Log off</system:String>
+    <system:String x:Key="wox_plugin_sys_lock_command">Lock</system:String>
+    <system:String x:Key="wox_plugin_sys_exit_command">Exit</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_command">Restart Wox</system:String>
+    <system:String x:Key="wox_plugin_sys_setting_command">Settings</system:String>
+    <system:String x:Key="wox_plugin_sys_sleep_command">Sleep</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate_command">Hibernate</system:String>
+    <system:String x:Key="wox_plugin_sys_emptyrecyclebin_command">Empty Recycle Bin</system:String>
 
     <system:String x:Key="wox_plugin_sys_shutdown_computer">Shutdown Computer</system:String>
     <system:String x:Key="wox_plugin_sys_restart_computer">Restart Computer</system:String>
@@ -13,7 +21,11 @@
     <system:String x:Key="wox_plugin_sys_restart">Restart Wox</system:String>
     <system:String x:Key="wox_plugin_sys_setting">Tweak this app</system:String>
     <system:String x:Key="wox_plugin_sys_sleep">Put computer to sleep</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate">Hibernate computer</system:String>
     <system:String x:Key="wox_plugin_sys_emptyrecyclebin">Empty recycle bin</system:String>
+
+    <system:String x:Key="wox_plugin_sys_confirm_shutdown">Are you sure you want to shut the computer down?</system:String>
+    <system:String x:Key="wox_plugin_sys_confirm_restart">Are you sure you want to restart the computer?</system:String>
 
     <system:String x:Key="wox_plugin_sys_plugin_name">System Commands</system:String>
     <system:String x:Key="wox_plugin_sys_plugin_description">Provides System related commands. e.g. shutdown, lock, settings etc.</system:String>

--- a/Plugins/Wox.Plugin.Sys/Languages/es.xaml
+++ b/Plugins/Wox.Plugin.Sys/Languages/es.xaml
@@ -1,0 +1,33 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <system:String x:Key="wox_plugin_sys_command">Comando</system:String>
+    <system:String x:Key="wox_plugin_sys_desc">Descripción</system:String>
+
+    <system:String x:Key="wox_plugin_sys_shutdown_computer_command">Apagar</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_computer_command">Reiniciar</system:String>
+    <system:String x:Key="wox_plugin_sys_log_off_command">Desconectarse</system:String>
+    <system:String x:Key="wox_plugin_sys_lock_command">Bloquear</system:String>
+    <system:String x:Key="wox_plugin_sys_exit_command">Salida</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_command">Reiniciar Wox</system:String>
+    <system:String x:Key="wox_plugin_sys_setting_command">Ajustes</system:String>
+    <system:String x:Key="wox_plugin_sys_sleep_command">Suspender</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate_command">Hibernar</system:String>
+    <system:String x:Key="wox_plugin_sys_emptyrecyclebin_command">Vaciar papelera de reciclaje</system:String>
+
+    <system:String x:Key="wox_plugin_sys_shutdown_computer">Apagar la computadora</system:String>
+    <system:String x:Key="wox_plugin_sys_restart_computer">Reiniciar la computadora</system:String>
+    <system:String x:Key="wox_plugin_sys_log_off">Cerrar sesión</system:String>
+    <system:String x:Key="wox_plugin_sys_lock">Bloquea ésta computadora</system:String>
+    <system:String x:Key="wox_plugin_sys_exit">Cerrar wox</system:String>
+    <system:String x:Key="wox_plugin_sys_restart">Reiniciar wox</system:String>
+    <system:String x:Key="wox_plugin_sys_setting">Configurar esta aplicación</system:String>
+    <system:String x:Key="wox_plugin_sys_sleep">Suspende el ordenador</system:String>
+    <system:String x:Key="wox_plugin_sys_hibernate">Hibernar ordenador</system:String>
+    <system:String x:Key="wox_plugin_sys_emptyrecyclebin">Vaciar papelera de reciclaje</system:String>
+
+    <system:String x:Key="wox_plugin_sys_confirm_shutdown">¿Estás seguro de que quieres apagar el ordenador?</system:String>
+    <system:String x:Key="wox_plugin_sys_confirm_restart">¿Estás seguro de que deseas reiniciar el ordenador?</system:String>
+
+    <system:String x:Key="wox_plugin_sys_plugin_name">Comandos del sistema</system:String>
+    <system:String x:Key="wox_plugin_sys_plugin_description">Proporciona comandos relacionados con el sistema.  p.ej.  apagado, bloqueo, ajustes etc.</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -80,14 +80,14 @@ namespace Wox.Plugin.Sys
             {
                 new Result
                 {
-                    Title = "Shutdown",
+                    Title = context.API.GetTranslation("wox_plugin_sys_shutdown_computer_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_shutdown_computer"),
                     IcoPath = "Images\\shutdown.png",
                     Action = c =>
                     {
-                        var reuslt = MessageBox.Show("Are you sure you want to shut the computer down?",
+                        var result = MessageBox.Show(context.API.GetTranslation("wox_plugin_sys_confirm_shutdown"),
                                                      "Shutdown Computer?", MessageBoxButton.YesNo, MessageBoxImage.Warning);
-                        if (reuslt == MessageBoxResult.Yes)
+                        if (result == MessageBoxResult.Yes)
                         {
                             Process.Start("shutdown", "/s /t 0");
                         }
@@ -96,12 +96,12 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Restart",
+                    Title = context.API.GetTranslation("wox_plugin_sys_restart_computer_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_restart_computer"),
                     IcoPath = "Images\\restart.png",
                     Action = c =>
                     {
-                        var result = MessageBox.Show("Are you sure you want to restart the computer?",
+                        var result = MessageBox.Show(context.API.GetTranslation("wox_plugin_sys_confirm_restart"),
                                                      "Restart Computer?", MessageBoxButton.YesNo, MessageBoxImage.Warning);
                         if (result == MessageBoxResult.Yes)
                         {
@@ -112,14 +112,14 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Log off",
+                    Title = context.API.GetTranslation("wox_plugin_sys_log_off_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_log_off"),
                     IcoPath = "Images\\logoff.png",
                     Action = c => ExitWindowsEx(EWX_LOGOFF, 0)
                 },
                 new Result
                 {
-                    Title = "Lock",
+                    Title = context.API.GetTranslation("wox_plugin_sys_lock_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_lock"),
                     IcoPath = "Images\\lock.png",
                     Action = c =>
@@ -130,14 +130,21 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Sleep",
+                    Title = context.API.GetTranslation("wox_plugin_sys_sleep_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_sleep"),
                     IcoPath = "Images\\sleep.png",
                     Action = c => FormsApplication.SetSuspendState(PowerState.Suspend, false, false)
                 },
                 new Result
                 {
-                    Title = "Empty Recycle Bin",
+                    Title = context.API.GetTranslation("wox_plugin_sys_hibernate_command"),
+                    SubTitle = context.API.GetTranslation("wox_plugin_sys_hibernate"),
+                    IcoPath = "Images\\sleep.png", // Icon change needed
+                    Action = c => FormsApplication.SetSuspendState(PowerState.Hibernate, false, false)
+                },
+                new Result
+                {
+                    Title = context.API.GetTranslation("wox_plugin_sys_emptyrecyclebin_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_emptyrecyclebin"),
                     IcoPath = "Images\\recyclebin.png",
                     Action = c =>
@@ -158,7 +165,7 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Exit",
+                    Title = context.API.GetTranslation("wox_plugin_sys_exit_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_exit"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
@@ -169,7 +176,7 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Restart Wox",
+                    Title = context.API.GetTranslation("wox_plugin_sys_restart_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_restart"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
@@ -180,7 +187,7 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = "Settings",
+                    Title = context.API.GetTranslation("wox_plugin_sys_setting_command"),
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_setting"),
                     IcoPath = "Images\\app.png",
                     Action = c =>

--- a/Plugins/Wox.Plugin.Sys/Wox.Plugin.Sys.csproj
+++ b/Plugins/Wox.Plugin.Sys/Wox.Plugin.Sys.csproj
@@ -102,6 +102,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Languages\es.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Page Include="SysSettings.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Plugins/Wox.Plugin.Url/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Url/Languages/en.xaml
@@ -8,4 +8,8 @@
     <system:String x:Key="wox_plugin_url_plugin_name">URL</system:String>
     <system:String x:Key="wox_plugin_url_plugin_description">Open the typed URL from Wox</system:String>
 
+    <system:String x:Key="wox_plugin_url_plugin_set_tip">Please set your browser path:</system:String>
+    <system:String x:Key="wox_plugin_url_plugin_choose">Choose</system:String>
+    <system:String x:Key="wox_plugin_url_plugin_apply">Apply</system:String>
+    <system:String x:Key="wox_plugin_url_plugin_filter">Application(*.exe)|*.exe|All files|*.*</system:String>
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Url/Languages/zh-cn.xaml
+++ b/Plugins/Wox.Plugin.Url/Languages/zh-cn.xaml
@@ -8,4 +8,8 @@
     <system:String x:Key="wox_plugin_url_plugin_name">URL</system:String>
     <system:String x:Key="wox_plugin_url_plugin_description">从Wox打开链接</system:String>
 
+    <system:String x:Key="wox_plugin_url_plugin_set_tip">请设置你的浏览器路径:</system:String>
+    <system:String x:Key="wox_plugin_url_plugin_choose">选择</system:String>
+    <system:String x:Key="wox_plugin_url_plugin_apply">应用</system:String>
+    <system:String x:Key="wox_plugin_url_plugin_filter">程序文件(*.exe)|*.exe|所有文件|*.*</system:String>
 </ResourceDictionary>

--- a/Plugins/Wox.Plugin.Url/Settings.cs
+++ b/Plugins/Wox.Plugin.Url/Settings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wox.Plugin.Url
+{
+    public class Settings
+    {
+        public string BrowserPath { get; set; }
+    }
+}

--- a/Plugins/Wox.Plugin.Url/SettingsControl.xaml
+++ b/Plugins/Wox.Plugin.Url/SettingsControl.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="Wox.Plugin.Url.SettingsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Wox.Plugin.Url"
+             mc:Ignorable="d" Height="300" Width="500">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="0*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="0*"/>
+            <ColumnDefinition Width="0*"/>
+            <ColumnDefinition Width="0*"/>
+        </Grid.ColumnDefinitions>
+        <Label HorizontalAlignment="Left" Margin="99,22,0,0" VerticalAlignment="Top" Height="43" Width="318" FontSize="20" Content="{DynamicResource wox_plugin_url_plugin_set_tip}"/>
+        <TextBox x:Name="browserPathBox" HorizontalAlignment="Left" Height="34" Margin="35,90,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="311"/>
+        <Button x:Name="setButton" HorizontalAlignment="Left" Margin="356,247,0,0" VerticalAlignment="Top" Width="110" Height="33" FontSize="20" Click="OnApplyBTClick" Content="{DynamicResource wox_plugin_url_plugin_apply}"/>
+        <Button x:Name="viewButton" HorizontalAlignment="Left" Margin="369,90,0,0" VerticalAlignment="Top" Width="86" Height="34" Click="OnChooseClick" FontSize="20" Content="{DynamicResource wox_plugin_url_plugin_choose}"/>
+
+    </Grid>
+</UserControl>

--- a/Plugins/Wox.Plugin.Url/SettingsControl.xaml.cs
+++ b/Plugins/Wox.Plugin.Url/SettingsControl.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Microsoft.Win32;
+
+
+namespace Wox.Plugin.Url
+{
+    /// <summary>
+    /// SettingsControl.xaml 的交互逻辑
+    /// </summary>
+    public partial class SettingsControl : UserControl
+    {
+        private Settings _settings;
+        private IPublicAPI _woxAPI;
+
+        public SettingsControl(IPublicAPI woxAPI,Settings settings)
+        {
+            InitializeComponent();
+            _settings = settings;
+            _woxAPI = woxAPI;
+            browserPathBox.Text = _settings.BrowserPath;
+        }
+
+        private void OnApplyBTClick(object sender, RoutedEventArgs e)
+        {
+            _settings.BrowserPath = browserPathBox.Text;
+        }
+
+        private void OnChooseClick(object sender, RoutedEventArgs e)
+        {
+            var fileBrowserDialog = new OpenFileDialog();
+            fileBrowserDialog.Filter = _woxAPI.GetTranslation("wox_plugin_url_plugin_filter"); ;
+            fileBrowserDialog.CheckFileExists = true;
+            fileBrowserDialog.CheckPathExists = true;
+            if (fileBrowserDialog.ShowDialog() == true)
+            {
+                browserPathBox.Text = fileBrowserDialog.FileName;
+            }
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.Url/Wox.Plugin.Url.csproj
+++ b/Plugins/Wox.Plugin.Url/Wox.Plugin.Url.csproj
@@ -37,9 +37,12 @@
       <HintPath>..\..\packages\JetBrains.Annotations.10.3.0\lib\net\JetBrains.Annotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SolutionAssemblyInfo.cs">
@@ -47,6 +50,10 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Main.cs" />
+    <Compile Include="Settings.cs" />
+    <Compile Include="SettingsControl.xaml.cs">
+      <DependentUpon>SettingsControl.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -103,6 +110,12 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="SettingsControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WoX
 ===
 
-[![Build status](https://ci.appveyor.com/api/projects/status/bfktntbivg32e103/branch/master?svg=true)](https://ci.appveyor.com/project/happlebao/wox/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/bfktntbivg32e103?svg=true)](https://ci.appveyor.com/project/happlebao/wox)
 [![Github All Releases](https://img.shields.io/github/downloads/Wox-launcher/Wox/total.svg)](https://github.com/Wox-launcher/Wox/releases)
 [![RamenBless](https://cdn.rawgit.com/LunaGao/BlessYourCodeTag/master/tags/ramen.svg)](https://github.com/LunaGao/BlessYourCodeTag)
 

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -20,7 +20,7 @@ namespace Wox.Core.Resource
         public static Language Portuguese_BR = new Language("pt-br", "Português (Brasil)");
 		public static Language Italian = new Language("it", "Italiano");
         public static Language Norwegian_Bokmal = new Language("nb-NO", "Norsk Bokmål");
-	public static Language Slovak = new Language("sk", "Slovenský");
+        public static Language Slovak = new Language("sk", "Slovenský");
 
         public static List<Language> GetAvailableLanguages()
         {

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -18,7 +18,7 @@ namespace Wox.Core.Resource
         public static Language Korean = new Language("ko", "한국어");
         public static Language Serbian = new Language("sr", "Srpski");
         public static Language Portuguese_BR = new Language("pt-br", "Português (Brasil)");
-		public static Language Italian = new Language("it", "Italiano");
+	public static Language Italian = new Language("it", "Italiano");
         public static Language Norwegian_Bokmal = new Language("nb-NO", "Norsk Bokmål");
         public static Language Slovak = new Language("sk", "Slovenský");
 
@@ -40,8 +40,9 @@ namespace Wox.Core.Resource
                 Korean,
                 Serbian,
                 Portuguese_BR,
-				Italian,
-                Norwegian_Bokmal
+		Italian,
+                Norwegian_Bokmal,
+		Slovak
             };
             return languages;
         }

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Wox.Core.Resource
 {
@@ -20,6 +20,7 @@ namespace Wox.Core.Resource
         public static Language Portuguese_BR = new Language("pt-br", "Português (Brasil)");
 		public static Language Italian = new Language("it", "Italiano");
         public static Language Norwegian_Bokmal = new Language("nb-NO", "Norsk Bokmål");
+	public static Language Slovak = new Language("sk", "Slovenský");
 
         public static List<Language> GetAvailableLanguages()
         {

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -43,7 +43,7 @@ namespace Wox.Core.Resource
                 Portuguese_BR,
 		Italian,
                 Norwegian_Bokmal,
-		Slovak
+		Slovak,
 		        Espanol
             };
             return languages;

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -21,6 +21,7 @@ namespace Wox.Core.Resource
 	public static Language Italian = new Language("it", "Italiano");
         public static Language Norwegian_Bokmal = new Language("nb-NO", "Norsk Bokmål");
         public static Language Slovak = new Language("sk", "Slovenský");
+        public static Language Espanol = new Language("es", "Español");
 
         public static List<Language> GetAvailableLanguages()
         {
@@ -43,6 +44,7 @@ namespace Wox.Core.Resource
 		Italian,
                 Norwegian_Bokmal,
 		Slovak
+		        Espanol
             };
             return languages;
         }

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -43,7 +43,7 @@ namespace Wox.Core.Resource
                 Portuguese_BR,
 		Italian,
                 Norwegian_Bokmal,
-		Slovak,
+		Slovak
 		        Espanol
             };
             return languages;

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -18,7 +18,7 @@ namespace Wox.Core.Resource
         public static Language Korean = new Language("ko", "한국어");
         public static Language Serbian = new Language("sr", "Srpski");
         public static Language Portuguese_BR = new Language("pt-br", "Português (Brasil)");
-        public static Language Italian = new Language("it", "Italiano");
+	public static Language Italian = new Language("it", "Italiano");
         public static Language Norwegian_Bokmal = new Language("nb-NO", "Norsk Bokmål");
         public static Language Slovak = new Language("sk", "Slovenský");
         public static Language Espanol = new Language("es", "Español");
@@ -41,7 +41,7 @@ namespace Wox.Core.Resource
                 Korean,
                 Serbian,
                 Portuguese_BR,
-                Italian,
+		Italian,
                 Norwegian_Bokmal,
 		Slovak
 		        Espanol

--- a/Wox.Core/Resource/Theme.cs
+++ b/Wox.Core/Resource/Theme.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
+using System.Windows.Markup;
 using System.Windows.Media;
 using Wox.Infrastructure;
 using Wox.Infrastructure.Logger;
@@ -62,47 +63,50 @@ namespace Wox.Core.Resource
             }
         }
 
-        public void ChangeTheme(string theme)
+        public bool ChangeTheme(string theme)
         {
-            const string dark = "Dark";
-            bool valid;
+            const string defaultTheme = "Dark";
 
             string path = GetThemePath(theme);
-            if (string.IsNullOrEmpty(path))
+            try
             {
-                Log.Error($"|Theme.ChangeTheme|Theme path can't be found <{path}>, use default dark theme");
-                path = GetThemePath(dark);
                 if (string.IsNullOrEmpty(path))
-                {
-                    valid = false;
-                    Log.Error($"|Theme.ChangeTheme|Default theme path can't be found <{path}>");
-                }
-                else
-                {
-                    valid = true;
-                    theme = dark;
-                }
-            }
-            else
-            {
-                valid = true;
-            }
+                    throw new DirectoryNotFoundException("Theme path can't be found <{path}>");
 
-            if (valid)
-            {
                 Settings.Theme = theme;
 
                 var dicts = Application.Current.Resources.MergedDictionaries;
-                if (_oldTheme != theme)
+                //always allow re-loading default theme, in case of failure of switching to a new theme from default theme
+                if (_oldTheme != theme || theme == defaultTheme)
                 {
                     dicts.Remove(_oldResource);
-                    //fixme if something goes wrong here
                     var newResource = GetResourceDictionary();
                     dicts.Add(newResource);
                     _oldResource = newResource;
                     _oldTheme = Path.GetFileNameWithoutExtension(_oldResource.Source.AbsolutePath);
                 }
             }
+            catch (DirectoryNotFoundException e)
+            {
+                Log.Error($"|Theme.ChangeTheme|Theme <{theme}> path can't be found");
+                if (theme != defaultTheme)
+                {
+                    MessageBox.Show(string.Format(InternationalizationManager.Instance.GetTranslation("theme_load_failure_path_not_exists"), theme));
+                    ChangeTheme(defaultTheme);
+                }
+                return false;
+            }
+            catch (XamlParseException e)
+            {
+                Log.Error($"|Theme.ChangeTheme|Theme <{theme}> fail to parse");
+                if (theme != defaultTheme)
+                {
+                    MessageBox.Show(string.Format(InternationalizationManager.Instance.GetTranslation("theme_load_failure_parse_error"), theme));
+                    ChangeTheme(defaultTheme);
+                }
+                return false;
+            }
+            return true;
         }
 
         public ResourceDictionary GetResourceDictionary()

--- a/Wox.Core/Resource/Theme.cs
+++ b/Wox.Core/Resource/Theme.cs
@@ -22,10 +22,12 @@ namespace Wox.Core.Resource
         private const string Folder = "Themes";
         private const string Extension = ".xaml";
         private string DirectoryPath => Path.Combine(Constant.ProgramDirectory, Folder);
+        private string UserDirectoryPath => Path.Combine(Constant.DataDirectory, Folder);
 
         public Theme()
         {
             _themeDirectories.Add(DirectoryPath);
+            _themeDirectories.Add(UserDirectoryPath);
             MakesureThemeDirectoriesExist();
 
             var dicts = Application.Current.Resources.MergedDictionaries;
@@ -94,6 +96,7 @@ namespace Wox.Core.Resource
                 if (_oldTheme != theme)
                 {
                     dicts.Remove(_oldResource);
+                    //fixme if something goes wrong here
                     var newResource = GetResourceDictionary();
                     dicts.Add(newResource);
                     _oldResource = newResource;

--- a/Wox.Infrastructure/Image/ThumbnailReader.cs
+++ b/Wox.Infrastructure/Image/ThumbnailReader.cs
@@ -99,8 +99,8 @@ namespace Wox.Infrastructure.Image
             private int width;
             private int height;
 
-            public int Width { set => width = value; }
-            public int Height { set => height = value; }
+            public int Width { set { width = value; } }
+            public int Height { set { height = value; } }
         };
 
 

--- a/Wox/Languages/en.xaml
+++ b/Wox/Languages/en.xaml
@@ -52,6 +52,8 @@
     <system:String x:Key="resultItemFont">Result Item Font</system:String>
     <system:String x:Key="windowMode">Window Mode</system:String>
     <system:String x:Key="opacity">Opacity</system:String>
+    <system:String x:Key="theme_load_failure_path_not_exists">Theme {0} not exists, fallback to default theme</system:String>
+    <system:String x:Key="theme_load_failure_parse_error">Fail to load theme {0}, fallback to default theme</system:String>
 
     <!--Setting Hotkey-->
     <system:String x:Key="hotkey">Hotkey</system:String>

--- a/Wox/Languages/es.xaml
+++ b/Wox/Languages/es.xaml
@@ -1,0 +1,129 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+  <!--MainWindow-->
+  <system:String x:Key="registerHotkeyFailed">Error al registrar la tecla de acceso rápido: {0}</system:String>
+  <system:String x:Key="couldnotStartCmd">No se pudo iniciar {0}</system:String>
+  <system:String x:Key="invalidWoxPluginFileFormat">Formato de archivo de plugin Wox no válido</system:String>
+  <system:String x:Key="setAsTopMostInThisQuery">Establecer como máximo en esta consulta</system:String>
+  <system:String x:Key="cancelTopMostInThisQuery">Cancelar más arriba en esta consulta</system:String>
+  <system:String x:Key="executeQuery">Consulta de ejecución: {0}</system:String>
+  <system:String x:Key="lastExecuteTime">Último tiempo de ejecución: {0}</system:String>
+  <system:String x:Key="iconTrayOpen">Abrir</system:String>
+  <system:String x:Key="iconTraySettings">Ajustes</system:String>
+  <system:String x:Key="iconTrayAbout">Acerca de</system:String>
+  <system:String x:Key="iconTrayExit">Salir</system:String>
+  <!--Setting General-->
+  <system:String x:Key="wox_settings">Configuraciones Wox</system:String>
+  <system:String x:Key="general">General</system:String>
+  <system:String x:Key="startWoxOnSystemStartup">Iniciar Wox en el inicio del sistema</system:String>
+  <system:String x:Key="hideWoxWhenLoseFocus">Ocultar Wox cuando se pierde el enfoque</system:String>
+  <system:String x:Key="dontPromptUpdateMsg">No mostrar notificaciones de nuevas versiones.</system:String>
+  <system:String x:Key="rememberLastLocation">Recuerde la última ubicación de lanzamiento</system:String>
+  <system:String x:Key="language">Idioma</system:String>
+  <system:String x:Key="lastQueryMode">Último estilo de consulta</system:String>
+  <system:String x:Key="LastQueryPreserved">Preservar la última consulta</system:String>
+  <system:String x:Key="LastQuerySelected">Seleccione la última consulta</system:String>
+  <system:String x:Key="LastQueryEmpty">Vaciar última consulta</system:String>
+  <system:String x:Key="maxShowResults">Máximos resultados mostrados</system:String>
+  <system:String x:Key="ignoreHotkeysOnFullscreen">Ignorar teclas de acceso rápido en modo de pantalla completa</system:String>
+  <system:String x:Key="pythonDirectory">Directorio de Python</system:String>
+  <system:String x:Key="autoUpdates">Auto actualización</system:String>
+  <system:String x:Key="selectPythonDirectory">Seleccionar</system:String>
+  <system:String x:Key="hideOnStartup">Ocultar Wox en el inicio</system:String>
+  <system:String x:Key="hideNotifyIcon">Ocultar icono de bandeja</system:String>
+  <!--Setting Plugin-->
+  <system:String x:Key="plugin">Plugins</system:String>
+  <system:String x:Key="browserMorePlugins">Encuentra más complementos</system:String>
+  <system:String x:Key="disable">Inhabilitar</system:String>
+  <system:String x:Key="actionKeywords">Palabras clave de acción</system:String>
+  <system:String x:Key="pluginDirectory">Directorio de complementos</system:String>
+  <system:String x:Key="author">Autor</system:String>
+  <system:String x:Key="plugin_init_time">Tiempo de inicio: {0} ms</system:String>
+  <system:String x:Key="plugin_query_time">Tiempo de consulta: {0} ms</system:String>
+  <!--Setting Theme-->
+  <system:String x:Key="theme">Tema</system:String>
+  <system:String x:Key="browserMoreThemes">Navegar por más temas</system:String>
+  <system:String x:Key="helloWox">Hola wox</system:String>
+  <system:String x:Key="queryBoxFont">Fuente de consulta</system:String>
+  <system:String x:Key="resultItemFont">Fuente de elemento de resultado</system:String>
+  <system:String x:Key="windowMode">Modo ventana</system:String>
+  <system:String x:Key="opacity">Opacidad</system:String>
+  <system:String x:Key="theme_load_failure_path_not_exists">El tema {0} no existe, retrocede al tema predeterminado</system:String>
+  <system:String x:Key="theme_load_failure_parse_error">Error al cargar el tema {0}, retroceso al tema predeterminado</system:String>
+  <!--Setting Hotkey-->
+  <system:String x:Key="hotkey">Tecla de acceso directo</system:String>
+  <system:String x:Key="woxHotkey">Wox Hotkey</system:String>
+  <system:String x:Key="customQueryHotkey">Tecla rápida de consulta personalizada</system:String>
+  <system:String x:Key="delete">Borrar</system:String>
+  <system:String x:Key="edit">Editar</system:String>
+  <system:String x:Key="add">Añadir</system:String>
+  <system:String x:Key="pleaseSelectAnItem">Por favor seleccione un artículo</system:String>
+  <system:String x:Key="deleteCustomHotkeyWarning">¿Está seguro de que desea eliminar la tecla de acceso directo del complemento {0}?</system:String>
+  <!--Setting Proxy-->
+  <system:String x:Key="proxy">Proxy HTTP</system:String>
+  <system:String x:Key="enableProxy">Habilitar proxy HTTP</system:String>
+  <system:String x:Key="server">Servidor HTTP</system:String>
+  <system:String x:Key="port">Puerto</system:String>
+  <system:String x:Key="userName">Nombre de usuario</system:String>
+  <system:String x:Key="password">Contraseña</system:String>
+  <system:String x:Key="testProxy">Proxy de prueba</system:String>
+  <system:String x:Key="save">Salvar</system:String>
+  <system:String x:Key="serverCantBeEmpty">El campo del servidor no puede estar vacío</system:String>
+  <system:String x:Key="portCantBeEmpty">El campo del puerto no puede estar vacío</system:String>
+  <system:String x:Key="invalidPortFormat">Formato de puerto no válido</system:String>
+  <system:String x:Key="saveProxySuccessfully">Configuración de proxy guardada correctamente</system:String>
+  <system:String x:Key="proxyIsCorrect">Proxy configurado correctamente</system:String>
+  <system:String x:Key="proxyConnectFailed">Falló la conexión proxy</system:String>
+  <!--Setting About-->
+  <system:String x:Key="about">Acerca de</system:String>
+  <system:String x:Key="website">Sitio web</system:String>
+  <system:String x:Key="version">Versión</system:String>
+  <system:String x:Key="about_activate_times">Has activado Wox {0} veces.</system:String>
+  <system:String x:Key="checkUpdates">Buscar actualizaciones</system:String>
+  <system:String x:Key="newVersionTips">La nueva versión {0} está disponible, reinicia Wox.</system:String>
+  <system:String x:Key="checkUpdatesFailed">Las actualizaciones de verificación fallaron, verifique su conexión y la configuración del proxy en api.github.com.</system:String>
+  <system:String x:Key="downloadUpdatesFailed">
+Error al descargar las actualizaciones, verifique su conexión y la configuración del proxy en github-cloud.s3.amazonaws.com, o vaya a https://github.com/Wox-launcher/Wox/releases para descargar las actualizaciones manualmente.
+    </system:String>
+  <system:String x:Key="releaseNotes">Notas de lanzamiento:</system:String>
+  <!--Action Keyword Setting Dialog-->
+  <system:String x:Key="oldActionKeywords">Palabra clave de acción antigua</system:String>
+  <system:String x:Key="newActionKeywords">Nueva palabra clave de acción</system:String>
+  <system:String x:Key="cancel">Cancelar</system:String>
+  <system:String x:Key="done">Hecho</system:String>
+  <system:String x:Key="cannotFindSpecifiedPlugin">No puedo encontrar el plugin especificado</system:String>
+  <system:String x:Key="newActionKeywordsCannotBeEmpty">La nueva palabra clave de acción no puede estar vacía</system:String>
+  <system:String x:Key="newActionKeywordsHasBeenAssigned">Se han asignado nuevas palabras clave de acción a otro complemento, asigne otra palabra clave de acción nueva</system:String>
+  <system:String x:Key="succeed">Listo!</system:String>
+  <system:String x:Key="actionkeyword_tips">Utilice * si no desea especificar una palabra clave de acción</system:String>
+  <!--Custom Query Hotkey Dialog-->
+  <system:String x:Key="preview">Avance</system:String>
+  <system:String x:Key="hotkeyIsNotUnavailable">La tecla de acceso directo no está disponible, seleccione una nueva tecla de acceso rápido</system:String>
+  <system:String x:Key="invalidPluginHotkey">Tecla de acceso directo no válida</system:String>
+  <system:String x:Key="update">Actualizar</system:String>
+  <!--Hotkey Control-->
+  <system:String x:Key="hotkeyUnavailable">Hotkey no disponible</system:String>
+  <!--Crash Reporter-->
+  <system:String x:Key="reportWindow_version">Versión</system:String>
+  <system:String x:Key="reportWindow_time">Hora</system:String>
+  <system:String x:Key="reportWindow_reproduce">Por favor díganos cómo se bloqueó la aplicación para que podamos solucionarlo</system:String>
+  <system:String x:Key="reportWindow_send_report">Enviar reporte</system:String>
+  <system:String x:Key="reportWindow_cancel">Cancelar</system:String>
+  <system:String x:Key="reportWindow_general">General</system:String>
+  <system:String x:Key="reportWindow_exceptions">Excepciones</system:String>
+  <system:String x:Key="reportWindow_exception_type">Tipo de excepción</system:String>
+  <system:String x:Key="reportWindow_source">Fuente</system:String>
+  <system:String x:Key="reportWindow_stack_trace">Stack trace</system:String>
+  <system:String x:Key="reportWindow_sending">Enviando</system:String>
+  <system:String x:Key="reportWindow_report_succeed">Informe enviado correctamente</system:String>
+  <system:String x:Key="reportWindow_report_failed">Error al enviar el informe</system:String>
+  <system:String x:Key="reportWindow_wox_got_an_error">Wox tiene un error</system:String>
+  <!--update-->
+  <system:String x:Key="update_wox_update_new_version_available">La nueva versión de Wox {0} ya está disponible</system:String>
+  <system:String x:Key="update_wox_update_error">Se ha producido un error al intentar instalar actualizaciones de software.</system:String>
+  <system:String x:Key="update_wox_update">Actualizar</system:String>
+  <system:String x:Key="update_wox_update_cancel">Cancelar</system:String>
+  <system:String x:Key="update_wox_update_restart_wox_tip">Esta actualización reiniciará Wox</system:String>
+  <system:String x:Key="update_wox_update_upadte_files">Los siguientes archivos serán actualizados</system:String>
+  <system:String x:Key="update_wox_update_files">Actualizar archivos</system:String>
+  <system:String x:Key="update_wox_update_upadte_description">Actualización de la descripción</system:String>
+</ResourceDictionary>

--- a/Wox/Languages/ja.xaml
+++ b/Wox/Languages/ja.xaml
@@ -13,8 +13,6 @@
     <system:String x:Key="iconTraySettings">設定</system:String>
     <system:String x:Key="iconTrayAbout">Woxについて</system:String>
     <system:String x:Key="iconTrayExit">終了</system:String>
-    <system:String x:Key="pluginInitErrorsTitle">プラグイン初期化エラー</system:String>
-    <system:String x:Key="pluginInitErrorsBody">次のプラグインは初期化に失敗したため、無効になります：</system:String>
 
     <!--Setting General-->
     <system:String x:Key="wox_settings">Wox設定</system:String>
@@ -24,20 +22,17 @@
     <system:String x:Key="dontPromptUpdateMsg">最新版が入手可能であっても、アップグレードメッセージを表示しない</system:String>
     <system:String x:Key="rememberLastLocation">前回のランチャーの位置を記憶</system:String>
     <system:String x:Key="language">言語</system:String>
-    <!-- REQUIRES TRANSLATION. REMOVE COMMENT WHEN TRANSLATED -->
-    <system:String x:Key="lastQueryMode">Last Query Style</system:String>
-    <!-- REQUIRES TRANSLATION. REMOVE COMMENT WHEN TRANSLATED -->
-    <system:String x:Key="LastQueryPreserved">Preserve Last Query</system:String>
-    <!-- REQUIRES TRANSLATION. REMOVE COMMENT WHEN TRANSLATED -->
-    <system:String x:Key="LastQuerySelected">Select last Query</system:String>
-    <!-- REQUIRES TRANSLATION. REMOVE COMMENT WHEN TRANSLATED -->
-    <system:String x:Key="LastQueryEmpty">Empty last Query</system:String>
+    <system:String x:Key="lastQueryMode">前回のクエリの扱い</system:String>
+    <system:String x:Key="LastQueryPreserved">前回のクエリを保存</system:String>
+    <system:String x:Key="LastQuerySelected">前回のクエリを選択</system:String>
+    <system:String x:Key="LastQueryEmpty">前回のクエリを消去</system:String>
     <system:String x:Key="maxShowResults">結果の最大表示件数</system:String>
     <system:String x:Key="ignoreHotkeysOnFullscreen">ウィンドウがフルスクリーン時にホットキーを無効にする</system:String>
     <system:String x:Key="pythonDirectory">Pythonのディレクトリ</system:String>
     <system:String x:Key="autoUpdates">自動更新</system:String>
     <system:String x:Key="selectPythonDirectory">選択</system:String>
     <system:String x:Key="hideOnStartup">起動時にWoxを隠す</system:String>
+    <system:String x:Key="hideNotifyIcon">トレイアイコンを隠す</system:String>
     
     <!--Setting Plugin-->
     <system:String x:Key="plugin">プラグイン</system:String>
@@ -53,10 +48,12 @@
     <system:String x:Key="theme">テーマ</system:String>
     <system:String x:Key="browserMoreThemes">テーマを探す</system:String>
     <system:String x:Key="helloWox">こんにちは Wox</system:String>
-    <system:String x:Key="queryBoxFont">クエリボックスのフォント</system:String>
-    <system:String x:Key="resultItemFont">アイテムフォントの結果</system:String>
+    <system:String x:Key="queryBoxFont">検索ボックスのフォント</system:String>
+    <system:String x:Key="resultItemFont">検索結果一覧のフォント</system:String>
     <system:String x:Key="windowMode">ウィンドウモード</system:String>
     <system:String x:Key="opacity">透過度</system:String>
+    <system:String x:Key="theme_load_failure_path_not_exists">テーマ {0} が存在しません、デフォルトのテーマに戻します。</system:String>
+    <system:String x:Key="theme_load_failure_parse_error">テーマ {0} を読み込めません、デフォルトのテーマに戻します。</system:String>
     
     <!--Setting Hotkey-->
     <system:String x:Key="hotkey">ホットキー</system:String>
@@ -66,7 +63,7 @@
     <system:String x:Key="edit">編集</system:String>
     <system:String x:Key="add">追加</system:String>
     <system:String x:Key="pleaseSelectAnItem">項目選択してください</system:String>
-    <system:String x:Key="deleteCustomHotkeyWarning">{0} プラグインのホットキーを本当に削除しますか?</system:String>
+    <system:String x:Key="deleteCustomHotkeyWarning">{0} プラグインのホットキーを本当に削除しますか？</system:String>
 
     <!--Setting Proxy-->
     <system:String x:Key="proxy">HTTP プロキシ</system:String>
@@ -91,6 +88,11 @@
     <system:String x:Key="about_activate_times">あなたはWoxを {0} 回利用しました</system:String>
     <system:String x:Key="checkUpdates">アップデートを確認する</system:String>
     <system:String x:Key="newVersionTips">新しいバージョン {0} が利用可能です。Woxを再起動してください。</system:String>
+    <system:String x:Key="checkUpdatesFailed">アップデートの確認に失敗しました、api.github.com への接続とプロキシ設定を確認してください。</system:String>
+    <system:String x:Key="downloadUpdatesFailed">
+        更新のダウンロードに失敗しました、github-cloud.s3.amazonaws.com への接続とプロキシ設定を確認するか、
+        https://github.com/Wox-launcher/Wox/releases から手動でアップデートをダウンロードしてください。
+    </system:String>
     <system:String x:Key="releaseNotes">リリースノート:</system:String>
 
     <!--Action Keyword Setting Dialog-->

--- a/Wox/Languages/sk.xaml
+++ b/Wox/Languages/sk.xaml
@@ -1,0 +1,142 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <!--MainWindow-->
+    <system:String x:Key="registerHotkeyFailed">Nepodarilo sa registrovať klávesovú skratku {0}</system:String>
+    <system:String x:Key="couldnotStartCmd">Nepodarilo sa spustiť {0}</system:String>
+    <system:String x:Key="invalidWoxPluginFileFormat">Neplatný formát súboru pre plugin Wox</system:String>
+    <system:String x:Key="setAsTopMostInThisQuery">Pri tomto dopyte umiestniť navrchu</system:String>
+    <system:String x:Key="cancelTopMostInThisQuery">Zrušiť umiestnenie navrchu pri tomto dopyte</system:String>
+    <system:String x:Key="executeQuery">Spustiť dopyt: {0}</system:String>
+    <system:String x:Key="lastExecuteTime">Posledný čas realizácie: {0}</system:String>
+    <system:String x:Key="iconTrayOpen">Otvoriť</system:String>
+    <system:String x:Key="iconTraySettings">Nastavenia</system:String>
+    <system:String x:Key="iconTrayAbout">O aplikácii</system:String>
+    <system:String x:Key="iconTrayExit">Ukončiť</system:String>
+
+    <!--Setting General-->
+    <system:String x:Key="wox_settings">Nastavenia Wox</system:String>
+    <system:String x:Key="general">Všeobecné</system:String>
+    <system:String x:Key="startWoxOnSystemStartup">Spustiť Wox po štarte systému</system:String>
+    <system:String x:Key="hideWoxWhenLoseFocus">Schovať Wox po strate fokusu</system:String>
+    <system:String x:Key="dontPromptUpdateMsg">Nezobrazovať upozornenia na novú verziu</system:String>
+    <system:String x:Key="rememberLastLocation">Zapamätať si posledné umiestnenie</system:String>
+    <system:String x:Key="language">Jazyk</system:String>
+    <system:String x:Key="lastQueryMode">Posledný dopyt</system:String>
+    <system:String x:Key="LastQueryPreserved">Ponechať</system:String>
+    <system:String x:Key="LastQuerySelected">Označiť posledný dopyt</system:String>
+    <system:String x:Key="LastQueryEmpty">Prázdne</system:String>
+    <system:String x:Key="maxShowResults">Max. výsledkov</system:String>
+    <system:String x:Key="ignoreHotkeysOnFullscreen">Ignorovať klávesové skraty v režime na celú obrazovku</system:String>
+    <system:String x:Key="pythonDirectory">Priečinok s Pythonom</system:String>
+    <system:String x:Key="autoUpdates">Automatická aktualizácia</system:String>
+    <system:String x:Key="selectPythonDirectory">Vybrať</system:String>
+    <system:String x:Key="hideOnStartup">Schovať Wox po spustení</system:String>
+    <system:String x:Key="hideNotifyIcon">Schovať ikonu v oblasti oznámení</system:String>
+
+    <!--Setting Plugin-->
+    <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="browserMorePlugins">Nájsť ďalšie pluginy</system:String>
+    <system:String x:Key="disable">Zakázať</system:String>
+    <system:String x:Key="actionKeywords">Skratka akcie</system:String>
+    <system:String x:Key="pluginDirectory">Priečinok s pluginmy</system:String>
+    <system:String x:Key="author">Autor</system:String>
+    <system:String x:Key="plugin_init_time">Čas inic.: {0}ms</system:String>
+    <system:String x:Key="plugin_query_time">Čas dopytu: {0}ms</system:String>
+
+    <!--Setting Theme-->
+    <system:String x:Key="theme">Motív</system:String>
+    <system:String x:Key="browserMoreThemes">Prehliadať viac motívov</system:String>
+    <system:String x:Key="helloWox">Ahoj Wox</system:String>
+    <system:String x:Key="queryBoxFont">Písmo poľa pre dopyt</system:String>
+    <system:String x:Key="resultItemFont">Písmo výsledkov</system:String>
+    <system:String x:Key="windowMode">Režim okno</system:String>
+    <system:String x:Key="opacity">Nepriehľadnosť</system:String>
+
+    <!--Setting Hotkey-->
+    <system:String x:Key="hotkey">Klávesová skratka</system:String>
+    <system:String x:Key="woxHotkey">Klávesová skratka pre Wox</system:String>
+    <system:String x:Key="customQueryHotkey">Vlastná klávesová skratka pre dopyt</system:String>
+    <system:String x:Key="delete">Odstrániť</system:String>
+    <system:String x:Key="edit">Upraviť</system:String>
+    <system:String x:Key="add">Pridať</system:String>
+    <system:String x:Key="pleaseSelectAnItem">Vyberte položku, prosím</system:String>
+    <system:String x:Key="deleteCustomHotkeyWarning">Ste si istý, že chcete odstrániť klávesovú skratku {0} pre plugin?</system:String>
+
+    <!--Setting Proxy-->
+    <system:String x:Key="proxy">HTTP Proxy</system:String>
+    <system:String x:Key="enableProxy">Povoliť HTTP Proxy</system:String>
+    <system:String x:Key="server">HTTP Server</system:String>
+    <system:String x:Key="port">Port</system:String>
+    <system:String x:Key="userName">Používateľské meno</system:String>
+    <system:String x:Key="password">Heslo</system:String>
+    <system:String x:Key="testProxy">Test Proxy</system:String>
+    <system:String x:Key="save">Uložiť</system:String>
+    <system:String x:Key="serverCantBeEmpty">Pole Server nemôže byť prázdne</system:String>
+    <system:String x:Key="portCantBeEmpty">Pole Port nemôže byť prázdne</system:String>
+    <system:String x:Key="invalidPortFormat">Neplatný formát portu</system:String>
+    <system:String x:Key="saveProxySuccessfully">Nastavenie proxy úspešne uložené</system:String>
+    <system:String x:Key="proxyIsCorrect">Nastavenie proxy je v poriadku</system:String>
+    <system:String x:Key="proxyConnectFailed">Pripojenie proxy zlyhalo</system:String>
+
+    <!--Setting About-->
+    <system:String x:Key="about">O aplikácii</system:String>
+    <system:String x:Key="website">Webstránka</system:String>
+    <system:String x:Key="version">Verzia</system:String>
+    <system:String x:Key="about_activate_times">Wox bol aktivovaný {0}-krát</system:String>
+    <system:String x:Key="checkUpdates">Skontrolovať aktualizácie</system:String>
+    <system:String x:Key="newVersionTips">Je dostupná nová verzia {0}, prosím, reštartujte Wox.</system:String>
+    <system:String x:Key="checkUpdatesFailed">Kontrola aktualizácií zlyhala, prosím, skontrolujte pripojenie na internet a nastavenie proxy k api.github.com.</system:String>
+    <system:String x:Key="downloadUpdatesFailed">
+        Sťahovanie aktualizácií zlyhalo, skontrolujte pripojenie na internet a nastavenie proxy k github-cloud.s3.amazonaws.com, 
+        alebo prejdite na https://github.com/Wox-launcher/Wox/releases pre manuálne stiahnutie aktualizácií.
+    </system:String>
+    <system:String x:Key="releaseNotes">Poznámky k vydaniu:</system:String>
+
+    <!--Action Keyword Setting Dialog-->
+    <system:String x:Key="oldActionKeywords">Stará skratka akcie</system:String>
+    <system:String x:Key="newActionKeywords">Nová skratka akcie</system:String>
+    <system:String x:Key="cancel">Zrušiť</system:String>
+    <system:String x:Key="done">Hotovo</system:String>
+    <system:String x:Key="cannotFindSpecifiedPlugin">Nepodarilo sa nájsť zadaný plugin</system:String>
+    <system:String x:Key="newActionKeywordsCannotBeEmpty">Nová skratka pre akciu nemôže byť prázdna</system:String>
+    <system:String x:Key="newActionKeywordsHasBeenAssigned">Nová skratka pre akciu bola priradená pre iný plugin, prosím, zvoľte inú skratku</system:String>
+    <system:String x:Key="succeed">Úspešné</system:String>
+    <system:String x:Key="actionkeyword_tips">Použite * ak nechcete určiť skratku pre akciu</system:String>
+
+    <!--Custom Query Hotkey Dialog-->
+    <system:String x:Key="preview">Náhľad</system:String>
+    <system:String x:Key="hotkeyIsNotUnavailable">Klávesová skratka je nedostupná, prosím, zadajte novú</system:String>
+    <system:String x:Key="invalidPluginHotkey">Neplatná klávesová skratka pluginu</system:String>
+    <system:String x:Key="update">Aktualizovať</system:String>
+
+    <!--Hotkey Control-->
+    <system:String x:Key="hotkeyUnavailable">Klávesová skratka nedostupná</system:String>
+
+    <!--Crash Reporter-->
+    <system:String x:Key="reportWindow_version">Verzia</system:String>
+    <system:String x:Key="reportWindow_time">Čas</system:String>
+    <system:String x:Key="reportWindow_reproduce">Prosím, napíšte nám, ako došlo k pádu aplikácie, aby sme to mohli opraviť</system:String>
+    <system:String x:Key="reportWindow_send_report">Odoslať hlásenie</system:String>
+    <system:String x:Key="reportWindow_cancel">Zrušiť</system:String>
+    <system:String x:Key="reportWindow_general">Všeobecné</system:String>
+    <system:String x:Key="reportWindow_exceptions">Výnimky</system:String>
+    <system:String x:Key="reportWindow_exception_type">Typ výnimky</system:String>
+    <system:String x:Key="reportWindow_source">Zdroj</system:String>
+    <system:String x:Key="reportWindow_stack_trace">Stack Trace</system:String>
+    <system:String x:Key="reportWindow_sending">Odosiela sa</system:String>
+    <system:String x:Key="reportWindow_report_succeed">Hlásenie bolo úspešne odoslané</system:String>
+    <system:String x:Key="reportWindow_report_failed">Odoslanie hlásenia zlyhalo</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">Wox zaznamenal chybu</system:String>
+
+    <!--update-->
+    <system:String x:Key="update_wox_update_new_version_available">Je dostupné nové vydanie Wox {0}</system:String>
+    <system:String x:Key="update_wox_update_error">Počas inštalácie aktualizácií došlo k chybe</system:String>
+    <system:String x:Key="update_wox_update">Aktualizovať</system:String>
+    <system:String x:Key="update_wox_update_cancel">Zrušiť</system:String>
+    <system:String x:Key="update_wox_update_restart_wox_tip">Tento upgrade reštartuje Wox</system:String>
+    <system:String x:Key="update_wox_update_upadte_files">Nasledujúce súbory budú aktualizované</system:String>
+    <system:String x:Key="update_wox_update_files">Aktualizovať súbory</system:String>
+    <system:String x:Key="update_wox_update_upadte_description">Aktualizovať popis</system:String>
+
+</ResourceDictionary>

--- a/Wox/Languages/zh-cn.xaml
+++ b/Wox/Languages/zh-cn.xaml
@@ -52,6 +52,8 @@
     <system:String x:Key="resultItemFont">结果项字体</system:String>
     <system:String x:Key="windowMode">窗口模式</system:String>
     <system:String x:Key="opacity">透明度</system:String>
+    <system:String x:Key="theme_load_failure_path_not_exists">无法找到主题 {0} ，切换为默认主题</system:String>
+    <system:String x:Key="theme_load_failure_parse_error">无法加载主题 {0} ，切换为默认主题</system:String>
     
     <!--设置，热键-->
     <system:String x:Key="hotkey">热键</system:String>

--- a/Wox/ResultListBox.xaml
+++ b/Wox/ResultListBox.xaml
@@ -16,7 +16,8 @@
          KeyboardNavigation.DirectionalNavigation="Cycle" SelectionMode="Single"
          VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Standard"
          SelectionChanged="OnSelectionChanged"
-         IsSynchronizedWithCurrentItem="True">
+         IsSynchronizedWithCurrentItem="True"
+         PreviewMouseDown="ListBox_PreviewMouseDown">
     <!--IsSynchronizedWithCurrentItem: http://stackoverflow.com/a/7833798/2833083-->
     <ListBox.ItemTemplate>
         <DataTemplate>
@@ -65,6 +66,7 @@
     <ListBox.ItemContainerStyle>
         <Style TargetType="{x:Type ListBoxItem}">
             <EventSetter Event="MouseEnter" Handler="OnMouseEnter" />
+            <EventSetter Event="MouseMove" Handler="OnMouseMove" />
             <Setter Property="Height" Value="50" />
             <Setter Property="Margin" Value="0" />
             <Setter Property="Padding" Value="0" />

--- a/Wox/ResultListBox.xaml.cs
+++ b/Wox/ResultListBox.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Remoting.Contexts;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -7,6 +8,8 @@ namespace Wox
     [Synchronization]
     public partial class ResultListBox
     {
+        private Point _lastpos;
+        private ListBoxItem curItem = null;
         public ResultListBox()
         {
             InitializeComponent();
@@ -22,7 +25,26 @@ namespace Wox
 
         private void OnMouseEnter(object sender, MouseEventArgs e)
         {
-            ((ListBoxItem) sender).IsSelected = true;
+            curItem = (ListBoxItem)sender;
+            var p = e.GetPosition((IInputElement)sender);
+            _lastpos = p;
+        }
+
+        private void OnMouseMove(object sender, MouseEventArgs e)
+        {
+            var p = e.GetPosition((IInputElement)sender);
+            if (_lastpos != p)
+            {
+                ((ListBoxItem) sender).IsSelected = true;
+            }
+        }
+
+        private void ListBox_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (curItem != null)
+            {
+                curItem.IsSelected = true;
+            }
         }
     }
 }

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -138,7 +138,7 @@
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="{Binding PluginPair.Metadata.Name}"
-                                               ToolTip="{Binding PluginPair.Metadata.Name}"
+                                               ToolTip="{Binding PluginPair.Metadata.Version}"
                                                Grid.Column="0"
                                                Cursor="Hand" MouseUp="OnPluginNameClick" FontSize="24"
                                                HorizontalAlignment="Left" />

--- a/Wox/Themes/BlurBlack.xaml
+++ b/Wox/Themes/BlurBlack.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Base.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <system:Boolean x:Key="ThemeBlurEnabled">True</system:Boolean>

--- a/Wox/Themes/BlurWhite.xaml
+++ b/Wox/Themes/BlurWhite.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Base.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <system:Boolean x:Key="ThemeBlurEnabled">True</system:Boolean>

--- a/Wox/Themes/Dark.xaml
+++ b/Wox/Themes/Dark.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Base.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml" />
     </ResourceDictionary.MergedDictionaries>
     
     <Style x:Key="QueryBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">

--- a/Wox/Themes/Gray.xaml
+++ b/Wox/Themes/Gray.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Base.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml" />
     </ResourceDictionary.MergedDictionaries>
     <Style x:Key="QueryBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="#EDEDED" />

--- a/Wox/Themes/Light.xaml
+++ b/Wox/Themes/Light.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Base.xaml"></ResourceDictionary>
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml"></ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="QueryBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">

--- a/Wox/Themes/Metro Server.xaml
+++ b/Wox/Themes/Metro Server.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<ResourceDictionary.MergedDictionaries>
-		<ResourceDictionary Source="Base.xaml"></ResourceDictionary>
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml"></ResourceDictionary>
 	</ResourceDictionary.MergedDictionaries>
 	<Style x:Key="QueryBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">
 		<Setter Property="Background" Value="#ffffff"/>

--- a/Wox/Themes/Pink.xaml
+++ b/Wox/Themes/Pink.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Base.xaml"></ResourceDictionary>
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml"></ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
     <Style x:Key="QueryBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="#1f1d1f"/>

--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -128,7 +128,7 @@ namespace Wox.ViewModel
 
             StartHelpCommand = new RelayCommand(_ =>
             {
-                Process.Start("http://doc.getwox.com");
+                Process.Start("http://doc.wox.one/");
             });
 
             OpenResultCommand = new RelayCommand(index =>

--- a/Wox/ViewModel/SettingWindowViewModel.cs
+++ b/Wox/ViewModel/SettingWindowViewModel.cs
@@ -290,7 +290,7 @@ namespace Wox.ViewModel
             get
             {
                 var typeface = SyntaxSugars.CallOrRescueDefault(
-                    () => SelectedQueryBoxFont.ConvertFromInvariantStringsOrNormal(
+                    () => SelectedResultFont.ConvertFromInvariantStringsOrNormal(
                         Settings.ResultFontStyle,
                         Settings.ResultFontWeight,
                         Settings.ResultFontStretch

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell -command "$policy = Get-ExecutionPolicy"; "Set-ExecutionPolicy RemoteSigned"; "'-NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)'"; "Set-ExecutionPolicy $policy"</PostBuildEvent>
+    <PostBuildEvent>PowerShell -ExecutionPolicy Bypass -Command "$(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) '$(SolutionDir)'"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -308,6 +308,11 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Languages\sk.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>PowerShell -ExecutionPolicy Bypass -Command "$(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) '$(SolutionDir)'"</PostBuildEvent>
+    <PostBuildEvent>PowerShell -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell.exe -NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
+    <PostBuildEvent>powershell -command "$policy = Get-ExecutionPolicy"; "Set-ExecutionPolicy RemoteSigned"; "'-NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)'"; "Set-ExecutionPolicy $policy"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>PowerShell -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
+    <PostBuildEvent>powershell.exe -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -313,6 +313,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Languages\es.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
Not the best security practice requiring user to set PowerShell execution policy to unrestricted as per readme.

This simple change adds the Bypass flag so when building the Wox solution do not need to explicitly set local PS environment to Unrestricted.