### PR TITLE
Make Wox query fuzzy search more user friendly

### DIFF
--- a/Plugins/Wox.Plugin.ControlPanel/Main.cs
+++ b/Plugins/Wox.Plugin.ControlPanel/Main.cs
@@ -79,14 +79,14 @@ namespace Wox.Plugin.ControlPanel
             var scores = new List<int> {0};
             if (string.IsNullOrEmpty(item.LocalizedString))
             {
-                var score1 = StringMatcher.Score(item.LocalizedString, query);
+                var score1 = StringMatcher.FuzzySearch(query, item.LocalizedString).ScoreAfterSearchPrecisionFilter();
                 var score2 = StringMatcher.ScoreForPinyin(item.LocalizedString, query);
                 scores.Add(score1);
                 scores.Add(score2);
             }
             if (!string.IsNullOrEmpty(item.InfoTip))
             {
-                var score1 = StringMatcher.Score(item.InfoTip, query);
+                var score1 = StringMatcher.FuzzySearch(query, item.InfoTip).ScoreAfterSearchPrecisionFilter();
                 var score2 = StringMatcher.ScoreForPinyin(item.InfoTip, query);
                 scores.Add(score1);
                 scores.Add(score2);

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -240,9 +240,9 @@ namespace Wox.Plugin.Program.Programs
 
             private int Score(string query)
             {
-                var score1 = StringMatcher.Score(DisplayName, query);
+                var score1 = StringMatcher.FuzzySearch(query, DisplayName).ScoreAfterSearchPrecisionFilter();
                 var score2 = StringMatcher.ScoreForPinyin(DisplayName, query);
-                var score3 = StringMatcher.Score(Description, query);
+                var score3 = StringMatcher.FuzzySearch(query, Description).ScoreAfterSearchPrecisionFilter();
                 var score4 = StringMatcher.ScoreForPinyin(Description, query);
                 var score = new[] { score1, score2, score3, score4 }.Max();
                 return score;

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -31,11 +31,11 @@ namespace Wox.Plugin.Program.Programs
 
         private int Score(string query)
         {
-            var score1 = StringMatcher.Score(Name, query);
+            var score1 = StringMatcher.FuzzySearch(query, Name).ScoreAfterSearchPrecisionFilter();
             var score2 = StringMatcher.ScoreForPinyin(Name, query);
-            var score3 = StringMatcher.Score(Description, query);
+            var score3 = StringMatcher.FuzzySearch(query, Description).ScoreAfterSearchPrecisionFilter();
             var score4 = StringMatcher.ScoreForPinyin(Description, query);
-            var score5 = StringMatcher.Score(ExecutableName, query);
+            var score5 = StringMatcher.FuzzySearch(query, ExecutableName).ScoreAfterSearchPrecisionFilter();
             var score = new[] { score1, score2, score3, score4, score5 }.Max();
             return score;
         }

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -56,8 +56,8 @@ namespace Wox.Plugin.Sys
             var results = new List<Result>();
             foreach (var c in commands)
             {
-                var titleScore = StringMatcher.Score(c.Title, query.Search);
-                var subTitleScore = StringMatcher.Score(c.SubTitle, query.Search);
+                var titleScore = StringMatcher.FuzzySearch(query.Search, c.Title).ScoreAfterSearchPrecisionFilter();
+                var subTitleScore = StringMatcher.FuzzySearch(query.Search, c.SubTitle).ScoreAfterSearchPrecisionFilter();
                 var score = Math.Max(titleScore, subTitleScore);
                 if (score > 0)
                 {

--- a/Wox.Core/Resource/AvailableLanguages.cs
+++ b/Wox.Core/Resource/AvailableLanguages.cs
@@ -43,7 +43,7 @@ namespace Wox.Core.Resource
                 Portuguese_BR,
 		Italian,
                 Norwegian_Bokmal,
-		Slovak
+		Slovak,
 		        Espanol
             };
             return languages;

--- a/Wox.Infrastructure/FuzzyMatcher.cs
+++ b/Wox.Infrastructure/FuzzyMatcher.cs
@@ -1,10 +1,8 @@
-﻿using System.Text;
+﻿using System;
 
 namespace Wox.Infrastructure
 {
-    /// <summary>
-    /// refer to https://github.com/mattyork/fuzzy
-    /// </summary>
+    [Obsolete("This class is obsolete and should not be used. Please use the static function StringMatcher.FuzzySearch")]
     public class FuzzyMatcher
     {
         private string query;
@@ -28,99 +26,7 @@ namespace Wox.Infrastructure
 
         public MatchResult Evaluate(string str)
         {
-            if (string.IsNullOrEmpty(str) || string.IsNullOrEmpty(query)) return new MatchResult { Success = false };
-
-            var len = str.Length;
-            var compareString = opt.IgnoreCase ? str.ToLower() : str;
-            var pattern = opt.IgnoreCase ? query.ToLower() : query;
-
-            var sb = new StringBuilder(str.Length + (query.Length * (opt.Prefix.Length + opt.Suffix.Length)));
-            var patternIdx = 0;
-            var firstMatchIndex = -1;
-            var lastMatchIndex = 0;
-            char ch;
-            for (var idx = 0; idx < len; idx++)
-            {
-                ch = str[idx];
-                if (compareString[idx] == pattern[patternIdx])
-                {
-                    if (firstMatchIndex < 0)
-                        firstMatchIndex = idx;
-                    lastMatchIndex = idx + 1;
-
-                    sb.Append(opt.Prefix + ch + opt.Suffix);
-                    patternIdx += 1;
-                }
-                else
-                {
-                    sb.Append(ch);
-                }
-
-                // match success, append remain char
-                if (patternIdx == pattern.Length && (idx + 1) != compareString.Length)
-                {
-                    sb.Append(str.Substring(idx + 1));
-                    break;
-                }
-            }
-
-            // return rendered string if we have a match for every char
-            if (patternIdx == pattern.Length)
-            {
-                return new MatchResult
-                {
-                    Success = true,
-                    Value = sb.ToString(),
-                    Score = CalScore(str, firstMatchIndex, lastMatchIndex - firstMatchIndex)
-                };
-            }
-
-            return new MatchResult { Success = false };
+            return StringMatcher.FuzzySearch(query, str, opt);
         }
-
-        private int CalScore(string str, int firstIndex, int matchLen)
-        {
-            //a match found near the beginning of a string is scored more than a match found near the end
-            //a match is scored more if the characters in the patterns are closer to each other, while the score is lower if they are more spread out
-            var score = 100 * (query.Length + 1) / ((1 + firstIndex) + (matchLen + 1));
-            //a match with less characters assigning more weights
-            if (str.Length - query.Length < 5)
-                score = score + 20;
-            else if (str.Length - query.Length < 10)
-                score = score + 10;
-
-            return score;
-        }
-    }
-
-    public class MatchResult
-    {
-        public bool Success { get; set; }
-        public int Score { get; set; }
-        /// <summary>
-        /// hightlight string
-        /// </summary>
-        public string Value { get; set; }
-    }
-
-    public class MatchOption
-    {
-        public MatchOption()
-        {
-            Prefix = "";
-            Suffix = "";
-            IgnoreCase = true;
-        }
-
-        /// <summary>
-        /// prefix of match char, use for hightlight
-        /// </summary>
-        public string Prefix { get; set; }
-        /// <summary>
-        /// suffix of match char, use for hightlight
-        /// </summary>
-        public string Suffix { get; set; }
-
-        public bool IgnoreCase { get; set; }
     }
 }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -1,25 +1,128 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using Wox.Infrastructure;
+using System.Text;
 using Wox.Infrastructure.Logger;
+using Wox.Infrastructure.UserSettings;
 
 namespace Wox.Infrastructure
 {
     public static class StringMatcher
     {
+        public static string UserSettingSearchPrecision { get; set; }
+
+        [Obsolete("This method is obsolete and should not be used. Please use the static function StringMatcher.FuzzySearch")]
         public static int Score(string source, string target)
         {
             if (!string.IsNullOrEmpty(source) && !string.IsNullOrEmpty(target))
             {
-                FuzzyMatcher matcher = FuzzyMatcher.Create(target);
-                var score = matcher.Evaluate(source).Score;
-                return score;
+                return FuzzySearch(target, source, new MatchOption()).Score;
             }
             else
             {
                 return 0;
             }
+        }
+
+        [Obsolete("This method is obsolete and should not be used. Please use the static function StringMatcher.FuzzySearch")]
+        public static bool IsMatch(string source, string target)
+        {
+            return FuzzySearch(target, source, new MatchOption()).Score > 0;
+        }
+
+        public static MatchResult FuzzySearch(string query, string stringToCompare)
+        {
+            return FuzzySearch(query, stringToCompare, new MatchOption());
+        }
+
+        /// <summary>
+        /// refer to https://github.com/mattyork/fuzzy
+        /// </summary>
+        public static MatchResult FuzzySearch(string query, string stringToCompare, MatchOption opt)
+        {
+            if (string.IsNullOrEmpty(stringToCompare) || string.IsNullOrEmpty(query)) return new MatchResult { Success = false };
+
+            query.Trim();
+
+            var len = stringToCompare.Length;
+            var compareString = opt.IgnoreCase ? stringToCompare.ToLower() : stringToCompare;
+            var pattern = opt.IgnoreCase ? query.ToLower() : query;
+
+            var sb = new StringBuilder(stringToCompare.Length + (query.Length * (opt.Prefix.Length + opt.Suffix.Length)));
+            var patternIdx = 0;
+            var firstMatchIndex = -1;
+            var lastMatchIndex = 0;
+            char ch;
+            for (var idx = 0; idx < len; idx++)
+            {
+                ch = stringToCompare[idx];
+                if (compareString[idx] == pattern[patternIdx])
+                {
+                    if (firstMatchIndex < 0)
+                        firstMatchIndex = idx;
+                    lastMatchIndex = idx + 1;
+
+                    sb.Append(opt.Prefix + ch + opt.Suffix);
+                    patternIdx += 1;
+                }
+                else
+                {
+                    sb.Append(ch);
+                }
+
+                // match success, append remain char
+                if (patternIdx == pattern.Length && (idx + 1) != compareString.Length)
+                {
+                    sb.Append(stringToCompare.Substring(idx + 1));
+                    break;
+                }
+            }
+
+            // return rendered string if we have a match for every char
+            if (patternIdx == pattern.Length)
+            {
+                return new MatchResult
+                {
+                    Success = true,
+                    Value = sb.ToString(),
+                    Score = CalScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex)
+                };
+            }
+
+            return new MatchResult { Success = false };
+        }
+
+        private static int CalScore(string query, string stringToCompare, int firstIndex, int matchLen)
+        {
+            //a match found near the beginning of a string is scored more than a match found near the end
+            //a match is scored more if the characters in the patterns are closer to each other, while the score is lower if they are more spread out
+            var score = 100 * (query.Length + 1) / ((1 + firstIndex) + (matchLen + 1));
+            //a match with less characters assigning more weights
+            if (stringToCompare.Length - query.Length < 5)
+                score = score + 20;
+            else if (stringToCompare.Length - query.Length < 10)
+                score = score + 10;
+
+            return score;
+        }
+
+        public enum SearchPrecisionScore
+        {
+            Regular = 50,
+            Low = 20,
+            None = 0
+        }
+
+        public static bool IsSearchPrecisionScoreMet(this MatchResult matchResult)
+        {            
+            var precisionScore = (SearchPrecisionScore)Enum.Parse(typeof(SearchPrecisionScore), 
+                                                                            UserSettingSearchPrecision ?? SearchPrecisionScore.Regular.ToString());
+            return matchResult.Score >= (int)precisionScore;
+        }
+
+        public static int ScoreAfterSearchPrecisionFilter(this MatchResult matchResult)
+        {
+            return matchResult.IsSearchPrecisionScoreMet() ? matchResult.Score : 0;
+
         }
 
         public static int ScoreForPinyin(string source, string target)
@@ -34,12 +137,12 @@ namespace Wox.Infrastructure
                 
                 if (Alphabet.ContainsChinese(source))
                 {
-                    FuzzyMatcher matcher = FuzzyMatcher.Create(target);
-                    var combination = Alphabet.PinyinComination(source);
-                    var pinyinScore = combination.Select(pinyin => matcher.Evaluate(string.Join("", pinyin)).Score)
+                    var combination = Alphabet.PinyinComination(source);                    
+                    var pinyinScore = combination
+                        .Select(pinyin => FuzzySearch(target, string.Join("", pinyin), new MatchOption()).Score)
                         .Max();
-                    var acronymScore = combination.Select(Alphabet.Acronym)
-                        .Select(pinyin => matcher.Evaluate(pinyin).Score)
+                    var acronymScore = combination.Select(Alphabet.Acronym)                        
+                        .Select(pinyin => FuzzySearch(target, pinyin, new MatchOption()).Score)
                         .Max();
                     var score = Math.Max(pinyinScore, acronymScore);
                     return score;
@@ -53,11 +156,37 @@ namespace Wox.Infrastructure
             {
                 return 0;
             }
+        }        
+    }
+
+    public class MatchResult
+    {
+        public bool Success { get; set; }
+        public int Score { get; set; }
+        /// <summary>
+        /// hightlight string
+        /// </summary>
+        public string Value { get; set; }
+    }
+
+    public class MatchOption
+    {
+        public MatchOption()
+        {
+            Prefix = "";
+            Suffix = "";
+            IgnoreCase = true;
         }
 
-        public static bool IsMatch(string source, string target)
-        {
-            return Score(source, target) > 0;
-        }
+        /// <summary>
+        /// prefix of match char, use for hightlight
+        /// </summary>
+        public string Prefix { get; set; }
+        /// <summary>
+        /// suffix of match char, use for hightlight
+        /// </summary>
+        public string Suffix { get; set; }
+
+        public bool IgnoreCase { get; set; }
     }
 }

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -22,7 +22,18 @@ namespace Wox.Infrastructure.UserSettings
         public string ResultFontStretch { get; set; }
 
         public bool AutoUpdates { get; set; } = true;
-
+		
+		private string _querySearchPrecision { get; set; } = StringMatcher.SearchPrecisionScore.Regular.ToString();
+        public string QuerySearchPrecision
+        {
+            get { return _querySearchPrecision; }
+            set
+            {
+                _querySearchPrecision = value;
+                StringMatcher.UserSettingSearchPrecision = value;
+            }
+        }
+		
         public double WindowLeft { get; set; }
         public double WindowTop { get; set; }
         public int MaxResultsToShow { get; set; } = 6;

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -76,16 +76,12 @@ namespace Wox.Test
 
             Assert.True(scoreResult == 0);
         }
-
-
-        //[TestCase("c", 50)]
-        //[TestCase("ch", 50)]
+        
         [TestCase("chr")]
         [TestCase("chrom")]
-        [TestCase("chrome")]
-        //[TestCase("chrom", 0)]
-        //[TestCase("cand", 50)]
-        //[TestCase("cpywa", 0)]
+        [TestCase("chrome")]        
+        [TestCase("cand")]
+        [TestCase("cpywa")]
         [TestCase("ccs")]
         public void WhenGivenStringsAndAppliedPrecisionFilteringThenShouldReturnGreaterThanPrecisionScoreResults(string searchTerm)
         {
@@ -162,9 +158,9 @@ namespace Wox.Test
             Assert.IsTrue(orderedResults[4].Score == 0 && orderedResults[4].Title == searchStrings[4]);
         }
 
-        [TestCase("goo", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]        
-        [TestCase("chr", "Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("goo", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("chr", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Low, true)]
+        [TestCase("chr", "Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("chr", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
         [TestCase("chr", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Low, true)]
         [TestCase("chr", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
@@ -172,7 +168,7 @@ namespace Wox.Test
         [TestCase("ccs", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Low, true)]
         [TestCase("cand", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("cand", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        public void WhenGivenDesiredPrecisionIsRegularShouldReturnAllResultsEqualGreaterThanRegular(string queryString, string compareString, 
+        public void WhenGivenDesiredPrecisionThenShouldReturnAllResultsGreaterOrEqual(string queryString, string compareString, 
                                                                                                         int expectedPrecisionScore, bool expectedPrecisionResult)
         {
             var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;            

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using Wox.Infrastructure;
@@ -9,6 +11,31 @@ namespace Wox.Test
     [TestFixture]
     public class FuzzyMatcherTest
     {
+        public List<string> GetSearchStrings() 
+            => new List<string>
+            {
+                "Chrome",
+                "Choose which programs you want Windows to use for activities like web browsing, editing photos, sending e-mail, and playing music.",
+                "Help cure hope raise on mind entity Chrome ",
+                "Candy Crush Saga from King",
+                "Uninstall or change programs on your computer",
+                "Add, change, and manage fonts on your computer",
+                "Last is chrome",
+                "1111"
+            };
+
+        public List<int> GetPrecisionScores()
+        {
+            var listToReturn = new List<int>();
+
+            Enum.GetValues(typeof(StringMatcher.SearchPrecisionScore))
+                .Cast<StringMatcher.SearchPrecisionScore>()
+                .ToList()
+                .ForEach(x => listToReturn.Add((int)x));
+
+            return listToReturn;
+        }
+
         [Test]
         public void MatchTest()
         {
@@ -28,7 +55,7 @@ namespace Wox.Test
                 results.Add(new Result
                 {
                     Title = str,
-                    Score = FuzzyMatcher.Create("inst").Evaluate(str).Score
+                    Score = StringMatcher.FuzzySearch("inst", str, new MatchOption()).Score
                 });
             }
 
@@ -38,6 +65,129 @@ namespace Wox.Test
             Assert.IsTrue(results[0].Title == "Inste");
             Assert.IsTrue(results[1].Title == "Install Package");
             Assert.IsTrue(results[2].Title == "file open in browser-test");
+        }
+
+        [TestCase("Chrome")]
+        public void WhenGivenNotAllCharactersFoundInSearchStringThenShouldReturnZeroScore(string searchString)
+        {
+            var compareString = "Can have rum only in my glass";
+
+            var scoreResult = StringMatcher.FuzzySearch(searchString, compareString, new MatchOption()).Score;
+
+            Assert.True(scoreResult == 0);
+        }
+
+
+        //[TestCase("c", 50)]
+        //[TestCase("ch", 50)]
+        [TestCase("chr")]
+        [TestCase("chrom")]
+        [TestCase("chrome")]
+        //[TestCase("chrom", 0)]
+        //[TestCase("cand", 50)]
+        //[TestCase("cpywa", 0)]
+        [TestCase("ccs")]
+        public void WhenGivenStringsAndAppliedPrecisionFilteringThenShouldReturnGreaterThanPrecisionScoreResults(string searchTerm)
+        {
+            var results = new List<Result>();
+            
+            foreach (var str in GetSearchStrings())
+            {
+                results.Add(new Result
+                {
+                    Title = str,
+                    Score = StringMatcher.FuzzySearch(searchTerm, str, new MatchOption()).Score
+                });
+            }            
+
+            foreach (var precisionScore in GetPrecisionScores())
+            {
+                var filteredResult = results.Where(result => result.Score >= precisionScore).Select(result => result).OrderByDescending(x => x.Score).ToList();
+
+                Debug.WriteLine("");
+                Debug.WriteLine("###############################################");
+                Debug.WriteLine("SEARCHTERM: " + searchTerm + ", GreaterThanSearchPrecisionScore: " + precisionScore);
+                foreach (var item in filteredResult)
+                {
+                    Debug.WriteLine("SCORE: " + item.Score.ToString() + ", FoundString: " + item.Title);
+                }
+                Debug.WriteLine("###############################################");
+                Debug.WriteLine("");
+
+                Assert.IsFalse(filteredResult.Any(x => x.Score < precisionScore));
+            }
+        }
+
+        [TestCase("chrome")]
+        public void WhenGivenStringsForCalScoreMethodThenShouldReturnCurrentScoring(string searchTerm)
+        {
+            var searchStrings = new List<string>
+            {
+                "Chrome",//SCORE: 107
+                "Last is chrome",//SCORE: 53
+                "Help cure hope raise on mind entity Chrome",//SCORE: 21
+                "Uninstall or change programs on your computer", //SCORE: 15
+                "Candy Crush Saga from King"//SCORE: 0
+            }
+            .OrderByDescending(x => x)
+            .ToList();
+
+            var results = new List<Result>();
+
+            foreach (var str in searchStrings)
+            {
+                results.Add(new Result
+                {
+                    Title = str,
+                    Score = StringMatcher.FuzzySearch(searchTerm, str, new MatchOption()).Score
+                });
+            }
+
+            var orderedResults = results.OrderByDescending(x => x.Title).ToList();
+
+            Debug.WriteLine("");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine("SEARCHTERM: " + searchTerm);
+            foreach (var item in orderedResults)
+            {
+                Debug.WriteLine("SCORE: " + item.Score.ToString() + ", FoundString: " + item.Title);
+            }
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine("");
+                       
+            Assert.IsTrue(orderedResults[0].Score == 15 && orderedResults[0].Title == searchStrings[0]);
+            Assert.IsTrue(orderedResults[1].Score == 53 && orderedResults[1].Title == searchStrings[1]);
+            Assert.IsTrue(orderedResults[2].Score == 21 && orderedResults[2].Title == searchStrings[2]);
+            Assert.IsTrue(orderedResults[3].Score == 107 && orderedResults[3].Title == searchStrings[3]);
+            Assert.IsTrue(orderedResults[4].Score == 0 && orderedResults[4].Title == searchStrings[4]);
+        }
+
+        [TestCase("goo", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]        
+        [TestCase("chr", "Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("chr", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Low, true)]
+        [TestCase("chr", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("chr", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Low, true)]
+        [TestCase("chr", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("chr", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.None, true)]
+        [TestCase("ccs", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Low, true)]
+        [TestCase("cand", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("cand", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        public void WhenGivenDesiredPrecisionIsRegularShouldReturnAllResultsEqualGreaterThanRegular(string queryString, string compareString, 
+                                                                                                        int expectedPrecisionScore, bool expectedPrecisionResult)
+        {
+            var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;            
+            StringMatcher.UserSettingSearchPrecision = expectedPrecisionString.ToString();
+            var matchResult = StringMatcher.FuzzySearch(queryString, compareString, new MatchOption());
+
+            Debug.WriteLine("");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine($"SearchTerm: {queryString} PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
+            Debug.WriteLine($"SCORE: {matchResult.Score.ToString()}, ComparedString: {compareString}");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine("");
+
+            var matchPrecisionResult = matchResult.IsSearchPrecisionScoreMet();            
+            Assert.IsTrue(matchPrecisionResult == expectedPrecisionResult);
         }
     }
 }

--- a/Wox.Test/Wox.Test.csproj
+++ b/Wox.Test/Wox.Test.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.15.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.15.1\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,10 +42,10 @@
       <HintPath>..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
@@ -76,6 +80,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.15.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.15.1\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Wox.Test/packages.config
+++ b/Wox.Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1409.1722" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.12.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.15.1" targetFramework="net452" />
 </packages>

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -54,6 +54,8 @@ namespace Wox
                 _settingsVM = new SettingWindowViewModel();
                 _settings = _settingsVM.Settings;
 
+                StringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
+
                 PluginManager.LoadPlugins(_settings.PluginSettings);
                 _mainVM = new MainViewModel(_settings);
                 var window = new MainWindow(_settings, _mainVM);

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -56,6 +56,12 @@
                     <TextBlock Text="{DynamicResource autoUpdates}" />
                 </CheckBox>
                 <StackPanel Margin="10" Orientation="Horizontal">
+                    <TextBlock Text="Query Search Precision" />
+                    <ComboBox Margin="10 0 0 0" Width="120"
+                              ItemsSource="{Binding QuerySearchPrecisionStrings}" 
+                              SelectedItem="{Binding Settings.QuerySearchPrecision}" />
+                </StackPanel>
+                <StackPanel Margin="10" Orientation="Horizontal">
                     <TextBlock Text="{DynamicResource lastQueryMode}" />
                     <ComboBox Margin="10 0 0 0" Width="120"
                               ItemsSource="{Binding LastQueryModes}" SelectedValue="{Binding Settings.LastQueryMode}"
@@ -138,7 +144,7 @@
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="{Binding PluginPair.Metadata.Name}"
-                                               ToolTip="{Binding PluginPair.Metadata.Version}"
+                                               ToolTip="{Binding PluginPair.Metadata.Name}"
                                                Grid.Column="0"
                                                Cursor="Hand" MouseUp="OnPluginNameClick" FontSize="24"
                                                HorizontalAlignment="Left" />

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -144,7 +144,7 @@
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="{Binding PluginPair.Metadata.Name}"
-                                               ToolTip="{Binding PluginPair.Metadata.Name}"
+                                               ToolTip="{Binding PluginPair.Metadata.Version}"
                                                Grid.Column="0"
                                                Cursor="Hand" MouseUp="OnPluginNameClick" FontSize="24"
                                                HorizontalAlignment="Left" />

--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -305,8 +305,8 @@ namespace Wox.ViewModel
                 {
                     var filtered = results.Where
                     (
-                        r => StringMatcher.IsMatch(r.Title, query) ||
-                             StringMatcher.IsMatch(r.SubTitle, query)
+                        r => StringMatcher.FuzzySearch(query, r.Title).IsSearchPrecisionScoreMet() 
+                            || StringMatcher.FuzzySearch(query, r.SubTitle).IsSearchPrecisionScoreMet()
                     ).ToList();
                     ContextMenu.AddResults(filtered, id);
                 }
@@ -348,8 +348,8 @@ namespace Wox.ViewModel
             {
                 var filtered = results.Where
                 (
-                    r => StringMatcher.IsMatch(r.Title, query) ||
-                         StringMatcher.IsMatch(r.SubTitle, query)
+                    r => StringMatcher.FuzzySearch(query, r.Title).IsSearchPrecisionScoreMet() ||
+                         StringMatcher.FuzzySearch(query, r.SubTitle).IsSearchPrecisionScoreMet()
                 ).ToList();
                 History.AddResults(filtered, id);
             }

--- a/Wox/ViewModel/SettingWindowViewModel.cs
+++ b/Wox/ViewModel/SettingWindowViewModel.cs
@@ -70,6 +70,20 @@ namespace Wox.ViewModel
             }
         }
 
+        public List<string> QuerySearchPrecisionStrings
+        {
+            get
+            { 
+                var precisionStrings = new List<string>();
+
+                var enumList = Enum.GetValues(typeof(StringMatcher.SearchPrecisionScore)).Cast<StringMatcher.SearchPrecisionScore>().ToList();
+
+                enumList.ForEach(x => precisionStrings.Add(x.ToString()));
+
+                return precisionStrings;
+            }
+        }
+
         private Internationalization _translater => InternationalizationManager.Instance;
         public List<Language> Languages => _translater.LoadAvailableLanguages();
         public IEnumerable<int> MaxResultsRange => Enumerable.Range(2, 16);


### PR DESCRIPTION
### Problem context:
Wox query search brings back too many irrelevant results. For example if I search for "chrom" it brings back a bunch of irrelevant programs such as "Candy Crush Saga from King".

This headache is evident in issues: https://github.com/Wox-launcher/Wox/issues/1845, https://github.com/Wox-launcher/Wox/issues/2351, https://github.com/Wox-launcher/Wox/issues/2246, https://github.com/Wox-launcher/Wox/issues/2304, https://github.com/Wox-launcher/Wox/issues/2479

### Reason:
Wox uses fuzzy search, to be more specific, it uses character matching to find the relevant strings. Candy Crush matches because its characters "[**C**]andy Crus[**h**] Saga f[**r**][**o**][**m**] King". After matching it also calculates a score of the match where it requires all characters to be matched, and also score based on the distance of each match to the first character.

This matching is OK and working as intended. However Wox returns all results with a score > 0. So this means a lot of matches with low scores such as the one above (score of 26) will get returned along with a good match of "Chrome" itself (with a score of 107).

### Solution:
Since fuzzy search and score calculation is working as intended, I will not be changing it. Instead adding a layer to the scoring. This means each search result after calculating the score we also filter it by precision score of 0- None, 20 - Low and 50- Regular. Only results with a score equal or greater will be returned. 

User will also be enabled to choose their preference.

### Changes:
- Added new unit tests to guard CalScore method, this is the one that does the score calculation, so it is necessary to benchmark its logic and prevent future changes from unintentionally changing it.

- Added unit tests for fuzzy search and precision score filtering

- Added code for precision score filtering 

- Added UI option for user to pick their preferred search precision in settings.

### Design change:
1. Made entire FuzzySearch class obsolete and moved fuzzy search method to StringMatcher class for the following reasons:
- I don't see a point of having them both as new-able classes. There is no inheritance in place to say FuzzyMatcher is a child class of StringMatcher. 

- So far in the code base I am seeing other plugins use a static method to new up a FuzzyMatcher class and all the class is used for is to run the logic to match characters and calculate scoring. Having them in non-static class is an overkill.

- In the code base StringMatcher just basically calls FuzzyMatcher directly by newing it up. No point then to have both classes.

- FuzzySearch logic seems to work and I don't see much plans to add new search method, and further I don't see inheritance or polymorphism logic in the code base.

2. Made StringMatcher static. If new search method ever comes along it can also live in the StringMatcher class.

Changes are backwards compatible. Calls to FuzzyMatcher class are rerouted to StringMatcher.

### Result:

![image](https://user-images.githubusercontent.com/26427004/65831476-32e54400-e2fd-11e9-9276-cba2ca937990.png)

Before:
![image](https://user-images.githubusercontent.com/26427004/65826719-20531680-e2cd-11e9-872d-8f08fe4fa924.png)

After this PR change:
![image](https://user-images.githubusercontent.com/26427004/65826748-c30b9500-e2cd-11e9-81f0-4da168278f1f.png)

**serenity!**