### PR TITLE
Imageoptimization #115 (from jjw24 fork)

### DIFF
--- a/Wox.Infrastructure/Image/ImageCache.cs
+++ b/Wox.Infrastructure/Image/ImageCache.cs
@@ -39,6 +39,19 @@ namespace Wox.Infrastructure.Image
             var contains = _data.ContainsKey(key);
             return contains;
         }
+
+        public int CacheSize()
+        {
+            return _data.Count;
+        }
+
+        /// <summary>
+        /// return the number of unique images in the cache (by reference not by checking images content)
+        /// </summary>
+        public int UniqueImagesInCache()
+        {
+            return _data.Values.Distinct().Count();
+        }
     }
 
 }

--- a/Wox.Infrastructure/Image/ImageHashGenerator.cs
+++ b/Wox.Infrastructure/Image/ImageHashGenerator.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace Wox.Infrastructure.Image
+{
+    public interface IImageHashGenerator
+    {
+        string GetHashFromImage(ImageSource image);
+    }
+    public class ImageHashGenerator : IImageHashGenerator
+    {
+        public string GetHashFromImage(ImageSource imageSource)
+        {
+            if (!(imageSource is BitmapSource image))
+            {
+                return null;
+            }
+
+            try
+            {
+                using (var outStream = new MemoryStream())
+                {
+                    // PngBitmapEncoder enc2 = new PngBitmapEncoder();
+                    // enc2.Frames.Add(BitmapFrame.Create(tt));
+                    
+                    var enc = new JpegBitmapEncoder();
+                    var bitmapFrame = BitmapFrame.Create(image);
+                    bitmapFrame.Freeze();
+                    enc.Frames.Add(bitmapFrame);
+                    enc.Save(outStream);
+                    var byteArray = outStream.GetBuffer();
+                    using (var sha1 = new SHA1CryptoServiceProvider())
+                    {
+                        var hash = Convert.ToBase64String(sha1.ComputeHash(byteArray));
+                        return hash;
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+
+        }
+    }
+}

--- a/Wox.Infrastructure/Image/ThumbnailReader.cs
+++ b/Wox.Infrastructure/Image/ThumbnailReader.cs
@@ -110,7 +110,6 @@ namespace Wox.Infrastructure.Image
 
             try
             {
-
                 return Imaging.CreateBitmapSourceFromHBitmap(hBitmap, IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
             }
             finally

--- a/Wox.Infrastructure/Wox.Infrastructure.csproj
+++ b/Wox.Infrastructure/Wox.Infrastructure.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Hotkey\InterceptKeys.cs" />
     <Compile Include="Hotkey\KeyEvent.cs" />
     <Compile Include="Image\ImageCache.cs" />
+    <Compile Include="Image\ImageHashGenerator.cs" />
     <Compile Include="Image\ImageLoader.cs" />
     <Compile Include="Image\ThumbnailReader.cs" />
     <Compile Include="Logger\Log.cs" />


### PR DESCRIPTION
Update Image Loader to hash all images and reused hashed images, this greatly reduce the cost of images memory on the process.
For example on my system after initial pre loading reduced memory of the process 162MB -> 101MB
and instead of loading 3700 images loaded only 338.
This come with a small cost of the hashing process but after some testing and benchmarks it seems it doesn't affect the overall experience of the application.