### PR TITLE
Message to activate plugin should only show when plugin is disabled, not when it is enabled.

### DIFF
--- a/Plugins/Wox.Plugin.PluginIndicator/Main.cs
+++ b/Plugins/Wox.Plugin.PluginIndicator/Main.cs
@@ -13,7 +13,7 @@ namespace Wox.Plugin.PluginIndicator
             var results = from keyword in PluginManager.NonGlobalPlugins.Keys
                           where keyword.StartsWith(query.Terms[0])
                           let metadata = PluginManager.NonGlobalPlugins[keyword].Metadata
-                          where !metadata.Disabled
+                          where metadata.Disabled
                           select new Result
                           {
                               Title = keyword,


### PR DESCRIPTION
If doing a web search with the websearch plugin, it keeps asking to activate plugin, even though it is enabled.
Investigation showed it was checking for !Disabled instead of Disabled.
