### PR TITLE
Put prebuild xcopy in quotes to allow directories with spaces

### DIFF
--- a/Wox.Infrastructure/Wox.Infrastructure.csproj
+++ b/Wox.Infrastructure/Wox.Infrastructure.csproj
@@ -112,7 +112,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
-	xcopy /Y $(PkgPinyin4DotNet)\pinyindb\unicode_to_hanyu_pinyin.txt $(TargetDir)pinyindb\
+	xcopy /Y "$(PkgPinyin4DotNet)\pinyindb\unicode_to_hanyu_pinyin.txt" "$(TargetDir)pinyindb\"
 	</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Put xcopy in quotes to allow for developer's machine to have a directory with spaces. 