### PR TITLE
bring Web Search plugin results with matched actionkeyword to near top of results

### DIFF
--- a/Plugins/Wox.Plugin.WebSearch/Main.cs
+++ b/Plugins/Wox.Plugin.WebSearch/Main.cs
@@ -56,7 +56,8 @@ namespace Wox.Plugin.WebSearch
                     if (string.IsNullOrEmpty(keyword))
                     {
                         var result = new Result
-                        {
+                        { 
+                            Score=100,
                             Title = subtitle,
                             SubTitle = string.Empty,
                             IcoPath = searchSource.IconPath
@@ -69,7 +70,7 @@ namespace Wox.Plugin.WebSearch
                         {
                             Title = title,
                             SubTitle = subtitle,
-                            Score = 6,
+                            Score = 100,
                             IcoPath = searchSource.IconPath,
                             ActionKeywordAssigned = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? string.Empty : searchSource.ActionKeyword,
                             Action = c =>


### PR DESCRIPTION
Previously web search was right at bottom of results, or sometimes not appearing at all (e.g. if there is even a part match with Everything which displayed 30 results before)

If there is a matched action keyword, we should assume the user wants to use the web search, and should appear near top.