### PR TITLE
Fix duplicate results in updates.

### DIFF
--- a/Wox/ViewModel/ResultsViewModel.cs
+++ b/Wox/ViewModel/ResultsViewModel.cs
@@ -168,6 +168,12 @@ namespace Wox.ViewModel
                 if (token.IsCancellationRequested) { return Results.ToList(); }
                 List<Result> resultsFromUpdates = updates.SelectMany(u => u.Results).ToList();
 
+                //remove duplicates in updates. 
+                //In WebSearch plugin, updates are added via normal result as well as RegisterResultsUpdatedEvent (from IResultUpdated)
+                var dups = resultsFromUpdates.GroupBy(s => s).Where(s => s.Count() > 1).Select(s => s.First());
+                foreach (var dup in dups)
+                     resultsFromUpdates.Remove(dup);
+
                 if (token.IsCancellationRequested) { return Results.ToList(); }
                 newResults.RemoveAll(r => updates.Any(u => u.ID == r.Result.PluginID));
 


### PR DESCRIPTION
In WebSearch plugin, updates are added via normal result (via QueryResults) as well as RegisterResultsUpdatedEvent (from IResultUpdated) which gives duplicates results.
This takes only one of these results.
(ps, branch name should have been just  FixDuplicates (not  Plugins.HelloWorldCSharp.FixDuplicates) 