### PR TITLE
Icon result: Fallback to plugin icon if result icon not set, and use full path

### DIFF
--- a/Wox.Core/Plugin/PluginManager.cs
+++ b/Wox.Core/Plugin/PluginManager.cs
@@ -206,7 +206,10 @@ namespace Wox.Core.Plugin
                 r.PluginDirectory = metadata.PluginDirectory;
                 r.PluginID = metadata.ID;
                 r.OriginQuery = query;
-
+                if(r.IcoPath==null)
+                    r.IcoPath = metadata.IcoPath;
+                else if(!Path.IsPathRooted(r.IcoPath))
+                    r.IcoPath = Path.Combine(r.PluginDirectory, r.IcoPath);
                 // ActionKeywordAssigned is used for constructing MainViewModel's query text auto-complete suggestions 
                 // Plugins may have multi-actionkeywords eg. WebSearches. In this scenario it needs to be overriden on the plugin level 
                 if (metadata.ActionKeywords.Count == 1)


### PR DESCRIPTION
If IcoPath is not explicitly set for a result by plugin, then fall back to IcoPath for the plugin as set in plugin.json. (Previously it was falling back to Wox default icon)

Also using the **full** IcoPath including plugin directory instead of relative path (because sometimes the relative path was being added to the program path, instead of the the plugin path. This also fixes possible cache issue if IcoPath has the same filenames in different plugins which would cache the same icon for multiple plugins)