### PR TITLE
fixed unhandled exception, which occurred inside the catch block

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -210,12 +210,19 @@ namespace Wox.Plugin.Program.Programs
                     }
                     catch (Exception e)
                     {
-                        e.Data.Add(nameof(u), u);
+                        Type t = u.GetType();
+                        if (t.IsSerializable)
+                        {
+                            e.Data.Add(nameof(u), u);
+                        }
+                        else
+                        {
+                            e.Data.Add(nameof(u), "Error: u not Serializable");
+                        }
                         e.Data.Add(nameof(p.Id.FullName), p.Id.FullName);
                         Logger.WoxError($"cannot get package {u} {p.Id.FullName}", e);
                         return false;
                     }
-
 
                     return valid;
                 });


### PR DESCRIPTION
fixed unhandled exception, which occurred inside the catch block, UWP.cs:line 213

System.ArgumentException
  HResult=0x80070057
  Message=Argument passed in is not serializable.
Parameter name: value
  Source=mscorlib
  StackTrace:
   at System.Collections.ListDictionaryInternal.Add(Object key, Object value)
   at Wox.Plugin.Program.Programs.UWP.<>c__DisplayClass27_0.<CurrentUserPackages>b__0(Package p) in UWP.cs:line 213
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at System.Collections.Concurrent.Partitioner.DynamicPartitionerForIEnumerable`1.InternalPartitionEnumerable.GrabChunk_Buffered(KeyValuePair`2[] destArray, Int32 requestedChunkSize, Int32& actualNumElementsGrabbed)

  This exception was originally thrown at this call stack:
    [External Code]
    Wox.Plugin.Program.Programs.UWP.CurrentUserPackages.AnonymousMethod__0(Windows.ApplicationModel.Package) in UWP.cs
    [External Code]