### PR TITLE
Ctrl + Enter runs application as administrator for Program Plugin

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -50,7 +50,10 @@ namespace Wox.Plugin.Program.Programs
                         WorkingDirectory = ParentDirectory
                     };
 
-                    Main.StartProcess(Process.Start, info);
+                    if (e.SpecialKeyState.CtrlPressed)
+                        Main.StartProcess(Process.Start, ShellCommand.SetProcessStartInfo(info.FileName, info.WorkingDirectory, "", "runas"));
+                    else
+                        Main.StartProcess(Process.Start, info);
 
                     return true;
                 }


### PR DESCRIPTION
Press Ctrl+Enter on the selected option to run it as administrator.
Useful for running apps that require administrator privileges