### PR TITLE
Add support for Unix-style path separators

### DIFF
--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -446,7 +446,8 @@ namespace Wox.ViewModel
 
             ProgressBarVisibility = Visibility.Hidden;
 
-            var queryText = QueryText.Trim();
+            // support unix-style path separators
+            var queryText = QueryText.Trim().Replace("/", "\\");
             Task.Run(() =>
             {
                 if (!string.IsNullOrEmpty(queryText))


### PR DESCRIPTION
I find the Windows path separator `\` inconvenient in comparison to the Unix-style `/`, so this patch just allows Windows paths with `/` to work correctly.

Sorry if this is a bad place to put this code, your recommendation would be appreciated.