### PR TITLE
Fix crash reporting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ Thanks
 
 I would like to thank
 
-- [Raygun](https://raygun.com/) for their free crash reporting account.
+- [Sentry](https://sentry.io/) for their free crash reporting account.
 - JetBrains for Open Source licence.


### PR DESCRIPTION
I was browsing [usages of the Sentry SDK](https://github.com/getsentry/sentry-dotnet/network/dependents?dependents_after=MTI4OTEwNjI2ODc) and spotted this great project.

Fixing the footer note.