### PR TITLE
Stopping progress bar animation while progress bar is hidden so that it won't consume cpu cycles.

### DIFF
--- a/Wox/MainWindow.xaml
+++ b/Wox/MainWindow.xaml
@@ -91,7 +91,7 @@
                 </TextBox>
             </Grid>
             <Line x:Name="ProgressBar" HorizontalAlignment="Right"
-                  Style="{DynamicResource PendingLineStyle}" Visibility="{Binding ProgressBarVisibility, Mode=TwoWay}" 
+                  Style="{DynamicResource PendingLineStyle}" Visibility="{Binding ProgressBarVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                   Y1="0" Y2="0" X2="100" Height="2" Width="752" StrokeThickness="1">
             </Line>
             <ContentControl>

--- a/Wox/MainWindow.xaml.cs
+++ b/Wox/MainWindow.xaml.cs
@@ -83,6 +83,19 @@ namespace Wox
                             _viewModel.LastQuerySelected = true;
                         }
                     }
+                    return;
+                }
+
+                if (e.PropertyName == nameof(MainViewModel.ProgressBarVisibility))
+                {
+                    if (_viewModel.ProgressBarVisibility == Visibility.Visible)
+                    {
+                        ProgressBar.BeginStoryboard(_progressBarStoryboard);
+                    }
+                    else
+                    {
+                        _progressBarStoryboard.Stop(ProgressBar);
+                    }
                 }
             };
             _settings.PropertyChanged += (o, e) =>
@@ -148,7 +161,6 @@ namespace Wox
             _progressBarStoryboard.Children.Add(da);
             _progressBarStoryboard.Children.Add(da1);
             _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
-            ProgressBar.BeginStoryboard(_progressBarStoryboard);
             _viewModel.ProgressBarVisibility = Visibility.Hidden;
         }
 


### PR DESCRIPTION
Right now Wox consumes a little bit of CPU even when it is hidden. This patch drops CPU usage to 0