### PR TITLE
Make Menu key behave like right clicking on an item

### DIFF
--- a/Wox/MainWindow.xaml
+++ b/Wox/MainWindow.xaml
@@ -49,6 +49,8 @@
         <KeyBinding Key="Enter" Command="{Binding OpenResultCommand}"></KeyBinding>
         <KeyBinding Key="Enter" Modifiers="Ctrl" Command="{Binding OpenResultCommand}"></KeyBinding>
         <KeyBinding Key="Enter" Modifiers="Alt" Command="{Binding OpenResultCommand}"></KeyBinding>
+        <KeyBinding Key="Apps" Command="{Binding LoadContextMenuCommand}"></KeyBinding>
+        <KeyBinding Key="F10" Modifiers="Shift" Command="{Binding LoadContextMenuCommand}"></KeyBinding>
         <KeyBinding Key="D1" Modifiers="Alt" Command="{Binding OpenResultCommand}" CommandParameter="0"></KeyBinding>
         <KeyBinding Key="D2" Modifiers="Alt" Command="{Binding OpenResultCommand}" CommandParameter="1"></KeyBinding>
         <KeyBinding Key="D3" Modifiers="Alt" Command="{Binding OpenResultCommand}" CommandParameter="2"></KeyBinding>
@@ -73,12 +75,13 @@
                     </TextBox.Text>
                 </TextBox>
                 <TextBox x:Name="QueryTextBox"
-                    Style="{DynamicResource QueryBoxStyle}"
+                     Style="{DynamicResource QueryBoxStyle}"
                      Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      PreviewDragOver="OnPreviewDragOver"
                      TextChanged="OnTextChanged"
                      AllowDrop="True"
-                     Visibility="Visible">
+                     Visibility="Visible"
+                     ContextMenuService.IsEnabled="False">
                     <TextBox.ContextMenu>
                         <ContextMenu>
                             <MenuItem Command="ApplicationCommands.Cut"/>


### PR DESCRIPTION
Right clicking on suggestions shows additional options, but you have to use a mouse to right click.

I quickly added a KeyBinding for it for the useless right click button on my keyboard, but also had to disable the custom context menu on the TextBox. (Also apparently Shift+F10 is a shortcut for that button, so I added a binding for it as well.)
I think the only thing may be missed is the Settings option, as I think people would rather use Ctrl+XCV than right clicking on the program, but settings can still be opened by right clicking on the tray icon.