### PR TITLE
Fix Firefox bookmark title null

### DIFF
--- a/Plugins/Wox.Plugin.BrowserBookmark/FirefoxBookmarks.cs
+++ b/Plugins/Wox.Plugin.BrowserBookmark/FirefoxBookmarks.cs
@@ -44,7 +44,7 @@ namespace Wox.Plugin.BrowserBookmark
                     while (reader.Read())
                     {
                         string url = reader.GetString(0) ?? string.Empty;
-                        string title = reader.GetString(1) ?? string.Empty;
+                        string title = !reader.IsDBNull(1) ? (reader.GetString(1) ?? string.Empty) : string.Empty;
                         Logger.WoxTrace($"Firefox bookmark: <{title}> <{url}>");
                         bookmarList.Add(new Bookmark()
                         {


### PR DESCRIPTION
SQLite reader was returning an issue when title was empty. Added a nullcheck.