### PR TITLE
update development instruction on cocoapods and backend

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -5,4 +5,5 @@
 - Install [Nodejs](https://nodejs.org) and [pnpm](https://pnpm.io/)
 - Install [Python](https://python.org/downloads) and [pip](https://pip.pypa.io/en/stable/installation/)
 - Install [Flutter](https://docs.flutter.dev/get-started/install)
+- For MacOS, you also need to install `cocoapods` via `brew install cocoapods`
 - Run `just dev` to build dependencies and start Wox in development mode

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,4 +6,5 @@
 - Install [Python](https://python.org/downloads) and [pip](https://pip.pypa.io/en/stable/installation/)
 - Install [Flutter](https://docs.flutter.dev/get-started/install)
 - For MacOS, you also need to install `cocoapods` via `brew install cocoapods`
-- Run `just dev` to build dependencies and start Wox in development mode
+- Run `just dev` to build dependencies 
+- Run `go run main.go` in `Wox` directory and start Wox built in the previous step


### PR DESCRIPTION
I got error message says `cocoapods` is not installed when running `just dev`, after running `brew install cocoapods` the issue was resolved.

I closed the terminal so I don't have the original log output now... sorry about that.

Also updated the document about starting backend before starting wox app, as per described in https://github.com/Wox-launcher/Wox/issues/4070#issuecomment-2288187279

I am new to the tech stack used by Wox, so please let me know if I missed anything. Thanks! 