### PR TITLE
feat(file): Implement search plugin via locate on Linux

### DIFF
--- a/wox.core/plugin/system/file/searcher_linux.go
+++ b/wox.core/plugin/system/file/searcher_linux.go
@@ -1,6 +1,63 @@
 package file
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type LocateOptions struct {
+	CaseInsensitive bool
+	MaxResults      int
+	Timeout         time.Duration
+}
+
+func LocateWithOptions(query string, opts LocateOptions) ([]string, error) {
+	ctx := context.Background()
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	args := []string{}
+	args = append(args, "-0")
+	args = append(args, "-b")
+
+	if opts.CaseInsensitive {
+		args = append(args, "-i")
+	}
+
+	if opts.MaxResults > 0 {
+		args = append(args, "-l", fmt.Sprintf("%d", opts.MaxResults))
+	}
+	args = append(args, query)
+
+	cmd := exec.CommandContext(ctx, "locate", args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("locate timed out (%s)", opts.Timeout)
+		}
+		return nil, fmt.Errorf("failed to run locate (%v): %s", err, out.String())
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\x00")
+	var results []string
+	for _, l := range lines {
+		if l != "" {
+			results = append(results, l)
+		}
+	}
+	return results, nil
+}
 
 var searcher Searcher = &LinuxSearcher{}
 
@@ -12,5 +69,25 @@ func (m *LinuxSearcher) Init(ctx context.Context) error {
 }
 
 func (m *LinuxSearcher) Search(pattern SearchPattern) ([]SearchResult, error) {
-	return []SearchResult{}, nil
+	options :=
+		LocateOptions{
+			CaseInsensitive: false,
+			MaxResults:      256,
+			Timeout:         200000000,
+		}
+	results, err := LocateWithOptions(pattern.Name, options)
+	if err != nil {
+		return []SearchResult{}, nil
+	}
+
+	var searchResults []SearchResult
+	for _, result := range results {
+		fileName := filepath.Base(result)
+		searchResults = append(searchResults, SearchResult{
+			Name: fileName,
+			Path: result,
+		})
+	}
+
+	return searchResults, nil
 }


### PR DESCRIPTION
- On Linux, launch prevailing locate command to search for files.
- The maximum number of results is currently limited to 256 which should be reasonable for GUI use case.