### PR TITLE
chore(converter): update converter plugin description and keywords to distinguish from calculator

### DIFF
--- a/wox.core/plugin/system/converter/converter.go
+++ b/wox.core/plugin/system/converter/converter.go
@@ -37,7 +37,7 @@ func (c *Converter) GetMetadata() plugin.Metadata {
 		Entry:         "",
 		TriggerKeywords: []string{
 			"*",
-			"calculator",
+			"converter",
 		},
 		Commands: []plugin.MetadataCommand{},
 		SupportedOS: []string{

--- a/wox.core/plugin/system/converter/converter.go
+++ b/wox.core/plugin/system/converter/converter.go
@@ -32,7 +32,7 @@ func (c *Converter) GetMetadata() plugin.Metadata {
 		Version:       "1.0.0",
 		MinWoxVersion: "2.0.0",
 		Runtime:       "Go",
-		Description:   "Calculator for Wox",
+		Description:   "Multi-unit calculator and converter for Wox",
 		Icon:          plugin.PluginConverterIcon.String(),
 		Entry:         "",
 		TriggerKeywords: []string{


### PR DESCRIPTION
It's strange that both the calculator and converter descriptions are "Calculator for Wox" and have the same keywords.