### PR TITLE
fix type conversion of request settings parameters

### DIFF
--- a/wox.core/ui/router.go
+++ b/wox.core/ui/router.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+
 	"wox/ai"
 	"wox/common"
 	"wox/i18n"
@@ -519,47 +521,67 @@ func handleSettingWoxUpdate(w http.ResponseWriter, r *http.Request) {
 	ctx := util.NewTraceContext()
 	woxSetting := setting.GetSettingManager().GetWoxSetting(ctx)
 
+	var vb bool
+	var vf float64
+	var vs string
+	switch v := kv.Value.(type) {
+	case bool:
+		vb = v
+	case float64:
+		vf = v
+	case string:
+		vs = v
+		vb1, err := strconv.ParseBool(vs)
+		if err == nil {
+			vb = vb1
+		}
+		vf1, err := strconv.ParseFloat(vs, 64)
+		if err == nil {
+			vf = vf1
+		}
+	}
+
 	switch kv.Key {
 	case "EnableAutostart":
-		woxSetting.EnableAutostart.Set(kv.Value.(bool))
+		woxSetting.EnableAutostart.Set(vb)
 	case "MainHotkey":
-		woxSetting.MainHotkey.Set(kv.Value.(string))
+		woxSetting.MainHotkey.Set(vs)
 	case "SelectionHotkey":
-		woxSetting.SelectionHotkey.Set(kv.Value.(string))
+		woxSetting.SelectionHotkey.Set(vs)
 	case "UsePinYin":
-		woxSetting.UsePinYin.Set(kv.Value.(bool))
+		woxSetting.UsePinYin.Set(vb)
 	case "SwitchInputMethodABC":
-		woxSetting.SwitchInputMethodABC.Set(kv.Value.(bool))
+		woxSetting.SwitchInputMethodABC.Set(vb)
 	case "HideOnStart":
-		woxSetting.HideOnStart.Set(kv.Value.(bool))
+		woxSetting.HideOnStart.Set(vb)
 	case "HideOnLostFocus":
-		woxSetting.HideOnLostFocus.Set(kv.Value.(bool))
+		woxSetting.HideOnLostFocus.Set(vb)
 	case "ShowTray":
-		woxSetting.ShowTray.Set(kv.Value.(bool))
+		woxSetting.ShowTray.Set(vb)
 	case "LangCode":
-		woxSetting.LangCode.Set(i18n.LangCode(kv.Value.(string)))
+		woxSetting.LangCode.Set(i18n.LangCode(vs))
 	case "QueryMode":
-		woxSetting.QueryMode.Set(setting.QueryMode(kv.Value.(string)))
+		woxSetting.QueryMode.Set(vs)
 	case "ShowPosition":
-		woxSetting.ShowPosition.Set(setting.PositionType(kv.Value.(string)))
+		woxSetting.ShowPosition.Set(setting.PositionType(vs))
 	case "EnableAutoBackup":
-		woxSetting.EnableAutoBackup.Set(kv.Value.(bool))
+		woxSetting.EnableAutoBackup.Set(vb)
 	case "EnableAutoUpdate":
-		woxSetting.EnableAutoUpdate.Set(kv.Value.(bool))
+		woxSetting.EnableAutoUpdate.Set(vb)
 	case "CustomPythonPath":
-		woxSetting.CustomPythonPath.Set(kv.Value.(string))
+		woxSetting.CustomPythonPath.Set(vs)
 	case "CustomNodejsPath":
-		woxSetting.CustomNodejsPath.Set(kv.Value.(string))
+		woxSetting.CustomNodejsPath.Set(vs)
 	case "HttpProxyEnabled":
-		woxSetting.HttpProxyEnabled.Set(kv.Value.(bool))
+		woxSetting.HttpProxyEnabled.Set(vb)
 	case "HttpProxyUrl":
-		woxSetting.HttpProxyUrl.Set(kv.Value.(string))
+		woxSetting.HttpProxyUrl.Set(vs)
 	case "AppWidth":
-		woxSetting.AppWidth.Set(int(kv.Value.(float64)))
+		woxSetting.AppWidth.Set(int(vf))
 	case "MaxResultCount":
-		woxSetting.MaxResultCount.Set(int(kv.Value.(float64)))
+		woxSetting.MaxResultCount.Set(int(vf))
 	case "ThemeId":
-		woxSetting.ThemeId.Set(kv.Value.(string))
+		woxSetting.ThemeId.Set(vs)
 	default:
 		writeErrorResponse(w, "unknown setting key: "+kv.Key)
 		return


### PR DESCRIPTION
#4266

```
[DBG] [Wox] http request panic panic，err: interface conversion: interface {} is string, not bool, stack: goroutine 5010 [running]:
runtime/debug.Stack()
	C:/Program Files/Go/src/runtime/debug/stack.go:26 +0x5e
wox/util.GoRecover({0x7ff667c7a078, 0xc000342510}, {0x7ff664cde23e, 0x12}, {0xc00082d898, 0x1, 0xc001688a80?})
	C:/dev/wox-actions-runner/_work/Wox/Wox/wox.core/util/goroutine.go:26 +0x78
panic({0x7ff664b4a940?, 0xc0054270b0?})
	C:/Program Files/Go/src/runtime/panic.go:783 +0x132
wox/ui.handleSettingWoxUpdate({0x7ff667c77e20, 0xc004a684b0}, 0xe8?)
	C:/dev/wox-actions-runner/_work/Wox/Wox/wox.core/ui/router.go:524 +0x91d
wox/ui.serveAndWait.func1({0x7ff667c77e20?, 0xc004a684b0?}, 0xc005427020?)
	C:/dev/wox-actions-runner/_work/Wox/Wox/wox.core/ui/http.go:84 +0x82
net/http.HandlerFunc.ServeHTTP(0xc000c5e6c0?, {0x7ff667c77e20?, 0xc004a684b0?}, 0x28?)
	C:/Program Files/Go/src/net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0xc000c11040?, {0x7ff667c77e20, 0xc004a684b0}, 0xc0003a63c0)
	C:/Program Files/Go/src/net/http/server.go:2861 +0x1c7
wox/ui.serveAndWait.(*Cors).Handler.func4({0x7ff667c77e20, 0xc004a684b0}, 0xc0003a63c0)
	C:/Users/qianl/go/pkg/mod/github.com/rs/cors@v1.11.1/cors.go:289 +0x164
net/http.HandlerFunc.ServeHTTP(0x7ff663e2c2c5?, {0x7ff667c77e20?, 0xc004a684b0?}, 0xc004a68401?)
	C:/Program Files/Go/src/net/http/server.go:2322 +0x29
net/http.serverHandler.ServeHTTP({0x7ff667c73bb0?}, {0x7ff667c77e20?, 0xc004a684b0?}, 0x1?)
	C:/Program Files/Go/src/net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc0014da750, {0x7ff667c7a078, 0xc0014bd6b0})
	C:/Program Files/Go/src/net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 126
	C:/Program Files/Go/src/net/http/server.go:3493 +0x485
```