### PR TITLE
fix(python_host): python plugin log rpc method param name correction

### DIFF
--- a/wox.plugin.host.python/src/wox_plugin_host/plugin_api.py
+++ b/wox.plugin.host.python/src/wox_plugin_host/plugin_api.py
@@ -88,7 +88,7 @@ class PluginAPI(PublicAPI):
 
     async def log(self, ctx: Context, level: str, msg: str) -> None:
         """Write log"""
-        await self.invoke_method(ctx, "Log", {"level": level, "message": msg})
+        await self.invoke_method(ctx, "Log", {"level": level, "msg": msg})
 
     async def get_translation(self, ctx: Context, key: str) -> str:
         """Get a translation for a key"""


### PR DESCRIPTION
The log method in the python plugin_api incorrectly pass the parameter `message`, which leads to failure. This parameter should be renamed to `msg` to resolve the issue.

https://github.com/Wox-launcher/Wox/blob/25179c20090bb3e40870aeead219b3610926b740/wox.core/plugin/host/host_websocket.go#L274-L279

according to nodejs publicAPI

https://github.com/Wox-launcher/Wox/blob/25179c20090bb3e40870aeead219b3610926b740/wox.plugin.host.nodejs/src/pluginAPI.ts#L73-L75