### PR TITLE
feat: add Open Plugin Settings action in Action Panel

### DIFF
--- a/wox.core/plugin/manager.go
+++ b/wox.core/plugin/manager.go
@@ -1156,7 +1156,7 @@ func (m *Manager) buildResultUI(resultCache *QueryResultCache, queryId string) Q
 			PreviewData: fmt.Sprintf("/preview?sessionId=%s&queryId=%s&id=%s", resultCache.Query.SessionId, queryId, uiResult.Id),
 		}
 	}
-	resultUI := uiResult.ToUI()
+	resultUI := uiResult.ToUI(resultCache.PluginInstance)
 	resultUI.QueryId = queryId
 	return resultUI
 }
@@ -1796,7 +1796,7 @@ func (m *Manager) QueryFallback(ctx context.Context, query Query, queryPlugin *I
 	}
 
 	queryResultsUI := lo.Map(queryResults, func(item QueryResult, index int) QueryResultUI {
-		return item.ToUI()
+		return item.ToUI(queryPlugin)
 	})
 	results = append(results, queryResultsUI...)
 	return results
@@ -1806,7 +1806,7 @@ func (m *Manager) queryParallel(ctx context.Context, pluginInstance *Instance, q
 	util.Go(ctx, fmt.Sprintf("[%s] parallel query", pluginInstance.GetName(ctx)), func() {
 		queryResults := m.queryForPlugin(ctx, pluginInstance, query)
 		results <- lo.Map(queryResults, func(item QueryResult, index int) QueryResultUI {
-			return item.ToUI()
+			return item.ToUI(pluginInstance)
 		})
 		counter.Add(-1)
 		if counter.Load() == 0 {
@@ -2318,7 +2318,7 @@ func (m *Manager) QueryMRU(ctx context.Context, sessionId string, queryId string
 			restored.Actions = append(restored.Actions, removeMRUAction)
 
 			polishedResult := m.PolishResult(ctx, pluginInstance, query, *restored)
-			results = append(results, polishedResult.ToUI())
+			results = append(results, polishedResult.ToUI(pluginInstance))
 		}
 	}
 

--- a/wox.core/plugin/query.go
+++ b/wox.core/plugin/query.go
@@ -212,7 +212,15 @@ type FormActionContext struct {
 	Values map[string]string
 }
 
-func (q *QueryResult) ToUI() QueryResultUI {
+func (q *QueryResult) ToUI(pluginInstance *Instance) QueryResultUI {
+	// Get plugin info from plugin instance
+	var pluginId string
+	var pluginName string
+	if pluginInstance != nil {
+		pluginId = pluginInstance.Metadata.Id
+		pluginName = pluginInstance.Metadata.GetName(context.Background())
+	}
+
 	return QueryResultUI{
 		Id:         q.Id,
 		Title:      q.Title,
@@ -241,22 +249,26 @@ func (q *QueryResult) ToUI() QueryResultUI {
 				IsSystemAction:         action.IsSystemAction,
 			}
 		}),
+		PluginId:   pluginId,
+		PluginName: pluginName,
 	}
 }
 
 type QueryResultUI struct {
-	QueryId    string
-	Id         string
-	Title      string
-	SubTitle   string
-	Icon       common.WoxImage
-	Preview    WoxPreview
-	Score      int64
-	Group      string
-	GroupScore int64
-	Tails      []QueryResultTail
-	Actions    []QueryResultActionUI
-	IsGroup    bool
+	QueryId     string
+	Id          string
+	Title       string
+	SubTitle    string
+	Icon        common.WoxImage
+	Preview     WoxPreview
+	Score       int64
+	Group       string
+	GroupScore  int64
+	Tails       []QueryResultTail
+	Actions     []QueryResultActionUI
+	IsGroup     bool
+	PluginId    string
+	PluginName  string
 }
 
 // PushResultsPayload is used to push additional results to UI for a query.

--- a/wox.ui.flutter/wox/lib/controllers/wox_launcher_controller.dart
+++ b/wox.ui.flutter/wox/lib/controllers/wox_launcher_controller.dart
@@ -58,6 +58,7 @@ class WoxLauncherController extends GetxController {
   static const String localActionTogglePreviewFullscreenId = "__local_toggle_preview_fullscreen__";
   static const String localActionPreviewSearchId = "__local_preview_search__";
   static const String localActionOpenUpdateId = "__local_open_update__";
+  static const String localActionOpenPluginSettingsId = "__local_open_plugin_settings__";
 
   //query related variables
   final currentQuery = PlainQuery.empty().obs;
@@ -438,6 +439,30 @@ class WoxLauncherController extends GetxController {
         ),
       );
     }
+
+    // Add "Open Plugin Settings" action for plugin results
+    actions.add(
+      WoxResultAction.local(
+        id: localActionOpenPluginSettingsId,
+        name: "Open Plugin Settings",
+        hotkey: "",
+        emoji: "⚙️",
+        handler: (traceId) {
+          final activeResult = getActiveResult();
+          if (activeResult == null) {
+            return false;
+          }
+          // Use pluginId from WoxQueryResult directly
+          final pluginId = activeResult.pluginId;
+          if (pluginId.isEmpty) {
+            return false;
+          }
+          // Open plugin settings with the plugin ID
+          openSetting(traceId, SettingWindowContext(path: "/plugin/setting", param: pluginId));
+          return true;
+        },
+      ),
+    );
 
     if (!isShowPreviewPanel.value) {
       return actions;

--- a/wox.ui.flutter/wox/lib/entity/wox_query.dart
+++ b/wox.ui.flutter/wox/lib/entity/wox_query.dart
@@ -105,6 +105,10 @@ class WoxQueryResult {
   // Used by the frontend to determine if this result is a group
   late bool isGroup;
 
+  // Plugin info that generated this result
+  late String pluginId;
+  late String pluginName;
+
   WoxQueryResult({
     required this.queryId,
     required this.id,
@@ -118,6 +122,8 @@ class WoxQueryResult {
     required this.tails,
     required this.actions,
     required this.isGroup,
+    required this.pluginId,
+    required this.pluginName,
   });
 
   WoxQueryResult.empty() {
@@ -133,6 +139,8 @@ class WoxQueryResult {
     tails = [];
     actions = [];
     isGroup = false;
+    pluginId = "";
+    pluginName = "";
   }
 
   WoxQueryResult.fromJson(Map<String, dynamic> json) {
@@ -167,6 +175,9 @@ class WoxQueryResult {
     }
 
     isGroup = json['IsGroup'] == true;
+
+    pluginId = json['PluginId'] ?? "";
+    pluginName = json['PluginName'] ?? "";
   }
 
   Map<String, dynamic> toJson() {
@@ -183,6 +194,8 @@ class WoxQueryResult {
     data['Actions'] = actions.map((v) => v.toJson()).toList();
     data['Tails'] = tails.map((v) => v.toJson()).toList();
     data['IsGroup'] = isGroup;
+    data['PluginId'] = pluginId;
+    data['PluginName'] = pluginName;
     return data;
   }
 }


### PR DESCRIPTION
## Summary

Add ability to open plugin settings directly from Action Panel.

## Changes

- Add `PluginId` and `PluginName` fields to `QueryResultUI` (Go)
- Pass plugin info from `PluginInstance` to UI layer
- Add `pluginId` and `pluginName` to `WoxQueryResult` (Flutter)
- Add 'Open Plugin Settings' action in Action Panel

## Usage

Users can right-click on any plugin search result and select
'Open Plugin Settings' to directly access the plugin's settings page.

## Related

See Flow Launcher issue: https://github.com/Flow-Launcher/Flow.Launcher/issues/4262