### PR TITLE
Add Open Plugin Settings system action

### DIFF
--- a/wox.core/plugin/manager.go
+++ b/wox.core/plugin/manager.go
@@ -873,7 +873,7 @@ func (m *Manager) GetResultForFailedQuery(ctx context.Context, pluginMetadata Me
 }
 
 func (m *Manager) getDefaultActions(ctx context.Context, pluginInstance *Instance, query Query, title, subTitle string) (defaultActions []QueryResultAction) {
-	const openPluginSettingsActionID = "wox.system.open_plugin_settings"
+	const openPluginSettingsActionID = "open_plugin_settings_" + util.GetRandomUuid()
 
 	// Declare both actions first
 	var addToFavoriteAction func(context.Context, ActionContext)
@@ -941,15 +941,13 @@ func (m *Manager) getDefaultActions(ctx context.Context, pluginInstance *Instanc
 		})
 	}
 
-	if len(pluginInstance.Metadata.SettingDefinitions) > 0 {
-		defaultActions = append(defaultActions, QueryResultAction{
-			Id:                     openPluginSettingsActionID,
-			Name:                   i18n.GetI18nManager().TranslateWox(ctx, "plugin_manager_open_plugin_settings"),
-			Icon:                   common.SettingIcon,
-			IsSystemAction:         true,
-			PreventHideAfterAction: true,
-		})
-	}
+	defaultActions = append(defaultActions, QueryResultAction{
+		Id:                     openPluginSettingsActionID,
+		Name:                   i18n.GetI18nManager().TranslateWox(ctx, "plugin_manager_open_plugin_settings"),
+		Icon:                   common.SettingIcon,
+		IsSystemAction:         true,
+		PreventHideAfterAction: true,
+	})
 
 	return defaultActions
 }
@@ -1170,8 +1168,6 @@ func (m *Manager) buildResultUI(resultCache *QueryResultCache, queryId string) Q
 	}
 	resultUI := uiResult.ToUI()
 	resultUI.QueryId = queryId
-	resultUI.PluginId = resultCache.PluginInstance.Metadata.Id
-	resultUI.PluginName = resultCache.PluginInstance.Metadata.GetName(context.Background())
 	return resultUI
 }
 
@@ -1810,10 +1806,7 @@ func (m *Manager) QueryFallback(ctx context.Context, query Query, queryPlugin *I
 	}
 
 	queryResultsUI := lo.Map(queryResults, func(item QueryResult, index int) QueryResultUI {
-		resultUI := item.ToUI()
-		resultUI.PluginId = queryPlugin.Metadata.Id
-		resultUI.PluginName = queryPlugin.GetName(ctx)
-		return resultUI
+		return item.ToUI()
 	})
 	results = append(results, queryResultsUI...)
 	return results
@@ -1823,10 +1816,7 @@ func (m *Manager) queryParallel(ctx context.Context, pluginInstance *Instance, q
 	util.Go(ctx, fmt.Sprintf("[%s] parallel query", pluginInstance.GetName(ctx)), func() {
 		queryResults := m.queryForPlugin(ctx, pluginInstance, query)
 		results <- lo.Map(queryResults, func(item QueryResult, index int) QueryResultUI {
-			resultUI := item.ToUI()
-			resultUI.PluginId = pluginInstance.Metadata.Id
-			resultUI.PluginName = pluginInstance.GetName(ctx)
-			return resultUI
+			return item.ToUI()
 		})
 		counter.Add(-1)
 		if counter.Load() == 0 {

--- a/wox.core/plugin/manager.go
+++ b/wox.core/plugin/manager.go
@@ -873,6 +873,8 @@ func (m *Manager) GetResultForFailedQuery(ctx context.Context, pluginMetadata Me
 }
 
 func (m *Manager) getDefaultActions(ctx context.Context, pluginInstance *Instance, query Query, title, subTitle string) (defaultActions []QueryResultAction) {
+	const openPluginSettingsActionID = "wox.system.open_plugin_settings"
+
 	// Declare both actions first
 	var addToFavoriteAction func(context.Context, ActionContext)
 	var removeFromFavoriteAction func(context.Context, ActionContext)
@@ -936,6 +938,16 @@ func (m *Manager) getDefaultActions(ctx context.Context, pluginInstance *Instanc
 			IsSystemAction:         true,
 			PreventHideAfterAction: true,
 			Action:                 addToFavoriteAction,
+		})
+	}
+
+	if len(pluginInstance.Metadata.SettingDefinitions) > 0 {
+		defaultActions = append(defaultActions, QueryResultAction{
+			Id:                     openPluginSettingsActionID,
+			Name:                   i18n.GetI18nManager().TranslateWox(ctx, "plugin_manager_open_plugin_settings"),
+			Icon:                   common.SettingIcon,
+			IsSystemAction:         true,
+			PreventHideAfterAction: true,
 		})
 	}
 
@@ -1158,6 +1170,8 @@ func (m *Manager) buildResultUI(resultCache *QueryResultCache, queryId string) Q
 	}
 	resultUI := uiResult.ToUI()
 	resultUI.QueryId = queryId
+	resultUI.PluginId = resultCache.PluginInstance.Metadata.Id
+	resultUI.PluginName = resultCache.PluginInstance.Metadata.GetName(context.Background())
 	return resultUI
 }
 
@@ -1796,7 +1810,10 @@ func (m *Manager) QueryFallback(ctx context.Context, query Query, queryPlugin *I
 	}
 
 	queryResultsUI := lo.Map(queryResults, func(item QueryResult, index int) QueryResultUI {
-		return item.ToUI()
+		resultUI := item.ToUI()
+		resultUI.PluginId = queryPlugin.Metadata.Id
+		resultUI.PluginName = queryPlugin.GetName(ctx)
+		return resultUI
 	})
 	results = append(results, queryResultsUI...)
 	return results
@@ -1806,7 +1823,10 @@ func (m *Manager) queryParallel(ctx context.Context, pluginInstance *Instance, q
 	util.Go(ctx, fmt.Sprintf("[%s] parallel query", pluginInstance.GetName(ctx)), func() {
 		queryResults := m.queryForPlugin(ctx, pluginInstance, query)
 		results <- lo.Map(queryResults, func(item QueryResult, index int) QueryResultUI {
-			return item.ToUI()
+			resultUI := item.ToUI()
+			resultUI.PluginId = pluginInstance.Metadata.Id
+			resultUI.PluginName = pluginInstance.GetName(ctx)
+			return resultUI
 		})
 		counter.Add(-1)
 		if counter.Load() == 0 {

--- a/wox.core/resource/lang/en_US.json
+++ b/wox.core/resource/lang/en_US.json
@@ -817,6 +817,7 @@
   "plugin_file_everything_please_run_everything": "Please run Everything",
   "plugin_file_everything_goto_website": "Go to Everything website",
   "plugin_manager_query_failed": "%s query failed",
+  "plugin_manager_open_plugin_settings": "Open Plugin Settings",
   "plugin_manager_unpin_in_query": "Unpin from current query",
   "plugin_manager_pin_in_query": "Pin in current query",
   "plugin_manager_pin_in_query_success": "Pinned, will be prioritized in current query",

--- a/wox.core/resource/lang/pt_BR.json
+++ b/wox.core/resource/lang/pt_BR.json
@@ -770,6 +770,7 @@
   "plugin_file_everything_please_run_everything": "Por favor, execute o Everything",
   "plugin_file_everything_goto_website": "Ir para o site do Everything",
   "plugin_manager_query_failed": "Consulta %s falhou",
+  "plugin_manager_open_plugin_settings": "Abrir configurações do plugin",
   "plugin_manager_unpin_in_query": "Desafixar da consulta atual",
   "plugin_manager_pin_in_query": "Fixar na consulta atual",
   "plugin_manager_pin_in_query_success": "Fixado, será priorizado na consulta atual",

--- a/wox.core/resource/lang/ru_RU.json
+++ b/wox.core/resource/lang/ru_RU.json
@@ -772,6 +772,7 @@
   "plugin_file_everything_please_run_everything": "Пожалуйста, запустите Everything",
   "plugin_file_everything_goto_website": "Перейти на сайт Everything",
   "plugin_manager_query_failed": "Запрос %s не выполнен",
+  "plugin_manager_open_plugin_settings": "Открыть настройки плагина",
   "plugin_manager_unpin_in_query": "Открепить от текущего запроса",
   "plugin_manager_pin_in_query": "Закрепить в текущем запросе",
   "plugin_manager_pin_in_query_success": "Закреплено, будет приоритетным в текущем запросе",

--- a/wox.core/resource/lang/zh_CN.json
+++ b/wox.core/resource/lang/zh_CN.json
@@ -818,6 +818,7 @@
   "plugin_file_everything_please_run_everything": "请运行 Everything",
   "plugin_file_everything_goto_website": "前往 Everything 官网",
   "plugin_manager_query_failed": "%s 查询失败",
+  "plugin_manager_open_plugin_settings": "打开插件设置",
   "plugin_manager_unpin_in_query": "取消查询置顶",
   "plugin_manager_pin_in_query": "在当前查询中置顶",
   "plugin_manager_pin_in_query_success": "已置顶，将在当前查询中优先显示",


### PR DESCRIPTION
When user right-clicks on a plugin search result, show an 'Open Plugin Settings' option that opens the plugin's settings page.

## Changes
- Add PluginId and PluginName fields to QueryResultUI
- Add system action wox.system.open_plugin_settings in getDefaultActions()
- Only show when plugin has settings (SettingDefinitions not empty)

## Files
- wox.core/plugin/manager.go
- wox.core/resource/lang/*.json