### PR TITLE
Add Screenshot OCR to store and update LuxTranslate URLs

### DIFF
--- a/store-plugin.json
+++ b/store-plugin.json
@@ -736,15 +736,15 @@
     "MinWoxVersion": "2.0.0",
     "Runtime": "nodejs",
     "Description": "i18n:plugin_description",
-    "IconUrl": "https://raw.githubusercontent.com/stmluyuer/LuxTranslate/main/images/app.svg",
-    "Website": "https://github.com/stmluyuer/LuxTranslate",
-    "DownloadUrl": "https://github.com/stmluyuer/LuxTranslate/releases/latest/download/wox.plugin.luxtranslate.wox",
+    "IconUrl": "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.LuxTranslate/main/images/app.svg",
+    "Website": "https://github.com/stmluyuer/Wox.Plugin.LuxTranslate",
+    "DownloadUrl": "https://github.com/stmluyuer/Wox.Plugin.LuxTranslate/releases/latest/download/wox.plugin.luxtranslate.wox",
     "ScreenshotUrls": [
-      "https://raw.githubusercontent.com/stmluyuer/LuxTranslate/main/screenshots/query-result.jpg",
-      "https://raw.githubusercontent.com/stmluyuer/LuxTranslate/main/screenshots/multi-provider-result.jpg",
-      "https://raw.githubusercontent.com/stmluyuer/LuxTranslate/main/screenshots/settings-basic.jpg",
-      "https://raw.githubusercontent.com/stmluyuer/LuxTranslate/main/screenshots/settings-llm-table.jpg",
-      "https://raw.githubusercontent.com/stmluyuer/LuxTranslate/main/screenshots/quick-query-tip.jpg"
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.LuxTranslate/main/screenshots/query-result.jpg",
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.LuxTranslate/main/screenshots/multi-provider-result.jpg",
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.LuxTranslate/main/screenshots/settings-basic.jpg",
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.LuxTranslate/main/screenshots/settings-llm-table.jpg",
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.LuxTranslate/main/screenshots/quick-query-tip.jpg"
     ],
     "SupportedOS": [
       "Windows",

--- a/store-plugin.json
+++ b/store-plugin.json
@@ -763,5 +763,37 @@
         "plugin_description": "在 Wox 中使用免配置翻译源和大模型翻译文本"
       }
     }
+  },
+  {
+    "Id": "76d3be7c-7f4d-4a9d-9f8a-1e8d4c6b5a2f",
+    "Name": "i18n:plugin_name",
+    "Author": "stmluyuer",
+    "Version": "0.1.0",
+    "MinWoxVersion": "2.0.0",
+    "Runtime": "nodejs",
+    "Description": "i18n:plugin_description",
+    "IconUrl": "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.ScreenshotOCR/main/images/app.svg",
+    "Website": "https://github.com/stmluyuer/Wox.Plugin.ScreenshotOCR",
+    "DownloadUrl": "https://github.com/stmluyuer/Wox.Plugin.ScreenshotOCR/releases/latest/download/wox.plugin.screenshotocr.wox",
+    "ScreenshotUrls": [
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.ScreenshotOCR/main/screenshots/command-help.jpg",
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.ScreenshotOCR/main/screenshots/settings.jpg",
+      "https://raw.githubusercontent.com/stmluyuer/Wox.Plugin.ScreenshotOCR/main/screenshots/model-config.jpg"
+    ],
+    "SupportedOS": [
+      "Windows"
+    ],
+    "DateCreated": "2026-04-28 20:07:14",
+    "DateUpdated": "2026-04-28 20:07:14",
+    "I18n": {
+      "en_US": {
+        "plugin_name": "Screenshot OCR",
+        "plugin_description": "Capture or read images, recognize text with online OCR, and send text to LuxTranslate"
+      },
+      "zh_CN": {
+        "plugin_name": "截图 OCR",
+        "plugin_description": "截图或读取图片，使用在线 OCR 识别文字，并发送给 LuxTranslate 翻译"
+      }
+    }
   }
 ]


### PR DESCRIPTION
这次主要做了两件事：

- 把 LuxTranslate 的 store URL 调整到现在更规范的仓库地址：`stmluyuer/Wox.Plugin.LuxTranslate`
- 新增 Screenshot OCR 插件到 Wox Store

Screenshot OCR 目前还不算特别完善。现在为了实现截图和 OCR 流程，插件里带了一个 .NET helper，这是我目前想到的比较可行的处理方式，后续如果有更好的方案会继续调整。

我看到最新的 Wox 2.0.3 已经自带截图能力，也试了一下，不过目前相关 API 看起来只有测试里可以用。如果后续 Wox 开放这部分 API，Screenshot OCR 可以直接改成使用 Wox 本体的截图能力。

另外这个插件的大部分代码是用 Codex 5.5 辅助完成的，我已经做了本地测试和检查。如果有不合适或需要调整的地方，可以直接指出来。
