### PR TITLE
feat(ui): add Ctrl+N and Ctrl+P keyboard shortcuts for navigation

### DIFF
--- a/wox.ui.flutter/wox/lib/components/wox_list_view.dart
+++ b/wox.ui.flutter/wox/lib/components/wox_list_view.dart
@@ -313,6 +313,23 @@ class WoxListView<T> extends StatelessWidget {
                 }
               }
 
+              // Emacs-style navigation: Ctrl+N / Ctrl+P move through items
+              // just like Arrow Down / Arrow Up.
+              if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+                  HardwareKeyboard.instance.isControlPressed &&
+                  !HardwareKeyboard.instance.isShiftPressed &&
+                  !HardwareKeyboard.instance.isAltPressed &&
+                  !HardwareKeyboard.instance.isMetaPressed) {
+                switch (event.logicalKey) {
+                  case LogicalKeyboardKey.keyN:
+                    controller.updateActiveIndexByDirection(traceId, WoxDirectionEnum.WOX_DIRECTION_DOWN.code);
+                    return KeyEventResult.handled;
+                  case LogicalKeyboardKey.keyP:
+                    controller.updateActiveIndexByDirection(traceId, WoxDirectionEnum.WOX_DIRECTION_UP.code);
+                    return KeyEventResult.handled;
+                }
+              }
+
               var pressedHotkey = WoxHotkey.parseNormalHotkeyFromEvent(event);
               if (pressedHotkey == null) {
                 return KeyEventResult.ignored;

--- a/wox.ui.flutter/wox/lib/modules/launcher/views/wox_query_box_view.dart
+++ b/wox.ui.flutter/wox/lib/modules/launcher/views/wox_query_box_view.dart
@@ -395,6 +395,24 @@ class WoxQueryBoxView extends GetView<WoxLauncherController> {
                   }
                 }
 
+                // Emacs-style navigation: Ctrl+N / Ctrl+P move through results
+                // just like Arrow Down / Arrow Up, so launcher users can keep
+                // their hands on the home row.
+                if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+                    HardwareKeyboard.instance.isControlPressed &&
+                    !HardwareKeyboard.instance.isShiftPressed &&
+                    !HardwareKeyboard.instance.isAltPressed &&
+                    !HardwareKeyboard.instance.isMetaPressed) {
+                  switch (event.logicalKey) {
+                    case LogicalKeyboardKey.keyN:
+                      controller.handleQueryBoxArrowDown();
+                      return KeyEventResult.handled;
+                    case LogicalKeyboardKey.keyP:
+                      controller.handleQueryBoxArrowUp();
+                      return KeyEventResult.handled;
+                  }
+                }
+
                 var pressedHotkey = WoxHotkey.parseNormalHotkeyFromEvent(event);
                 if (pressedHotkey == null) {
                   return KeyEventResult.ignored;


### PR DESCRIPTION
This kind of navigation is pretty common in other similar tools so it might be helpful here as well

- Ctrl+N → next item (equivalent to Arrow Down)
- Ctrl+P → previous item (equivalent to Arrow Up)