### PR TITLE
Add canonical storage conversion language

### DIFF
--- a/wox.core/plugin/system/converter/core/registry.go
+++ b/wox.core/plugin/system/converter/core/registry.go
@@ -17,6 +17,7 @@ const (
 	UnitTypeLength                      // For length units (millimeters, meters, etc.)
 	UnitTypeWeight                      // For weight units (grams, kilograms, etc.)
 	UnitTypeTemperature                 // For temperature units (celsius, fahrenheit, etc.)
+	UnitTypeStorage                     // For storage units (byte aliases in converter scope)
 )
 
 type Unit struct {

--- a/wox.core/plugin/system/converter/core/storage_glossary.go
+++ b/wox.core/plugin/system/converter/core/storage_glossary.go
@@ -1,0 +1,54 @@
+package core
+
+import "strings"
+
+type StorageUnitFamily string
+
+const (
+	StorageUnitFamilyByteBase StorageUnitFamily = "byte-base"
+	StorageUnitFamilyDecimal  StorageUnitFamily = "decimal"
+	StorageUnitFamilyBinary   StorageUnitFamily = "binary"
+)
+
+type StorageUnit struct {
+	Symbol string
+	Family StorageUnitFamily
+}
+
+type StorageGlossary struct {
+	aliases map[string]StorageUnit
+}
+
+func NewStorageGlossary() StorageGlossary {
+	aliases := map[string]StorageUnit{}
+
+	// Canonical unit range is intentionally bounded to byte through tera for both
+	// decimal (B, KB, MB, GB, TB) and binary (B, KiB, MiB, GiB, TiB) families.
+	registerAliases(aliases, StorageUnit{Symbol: "B", Family: StorageUnitFamilyByteBase}, "b", "byte", "bytes")
+	registerAliases(aliases, StorageUnit{Symbol: "KB", Family: StorageUnitFamilyDecimal}, "kb", "kilobyte", "kilobytes")
+	registerAliases(aliases, StorageUnit{Symbol: "MB", Family: StorageUnitFamilyDecimal}, "mb", "megabyte", "megabytes")
+	registerAliases(aliases, StorageUnit{Symbol: "GB", Family: StorageUnitFamilyDecimal}, "gb", "gigabyte", "gigabytes")
+	registerAliases(aliases, StorageUnit{Symbol: "TB", Family: StorageUnitFamilyDecimal}, "tb", "terabyte", "terabytes")
+
+	registerAliases(aliases, StorageUnit{Symbol: "KiB", Family: StorageUnitFamilyBinary}, "kib", "kibibyte", "kibibytes")
+	registerAliases(aliases, StorageUnit{Symbol: "MiB", Family: StorageUnitFamilyBinary}, "mib", "mebibyte", "mebibytes")
+	registerAliases(aliases, StorageUnit{Symbol: "GiB", Family: StorageUnitFamilyBinary}, "gib", "gibibyte", "gibibytes")
+	registerAliases(aliases, StorageUnit{Symbol: "TiB", Family: StorageUnitFamilyBinary}, "tib", "tebibyte", "tebibytes")
+
+	return StorageGlossary{aliases: aliases}
+}
+
+func (g StorageGlossary) ResolveStorageUnit(input string) (StorageUnit, bool) {
+	unit, ok := g.aliases[normalizeStorageAlias(input)]
+	return unit, ok
+}
+
+func normalizeStorageAlias(input string) string {
+	return strings.ToLower(strings.TrimSpace(input))
+}
+
+func registerAliases(aliases map[string]StorageUnit, unit StorageUnit, names ...string) {
+	for _, name := range names {
+		aliases[normalizeStorageAlias(name)] = unit
+	}
+}

--- a/wox.core/plugin/system/converter/core/storage_glossary.go
+++ b/wox.core/plugin/system/converter/core/storage_glossary.go
@@ -1,6 +1,9 @@
 package core
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 type StorageUnitFamily string
 
@@ -41,6 +44,21 @@ func NewStorageGlossary() StorageGlossary {
 func (g StorageGlossary) ResolveStorageUnit(input string) (StorageUnit, bool) {
 	unit, ok := g.aliases[normalizeStorageAlias(input)]
 	return unit, ok
+}
+
+// Aliases returns the supported storage aliases in deterministic, longest-first order.
+func (g StorageGlossary) Aliases() []string {
+	aliases := make([]string, 0, len(g.aliases))
+	for alias := range g.aliases {
+		aliases = append(aliases, alias)
+	}
+	sort.Slice(aliases, func(i, j int) bool {
+		if len(aliases[i]) == len(aliases[j]) {
+			return aliases[i] < aliases[j]
+		}
+		return len(aliases[i]) > len(aliases[j])
+	})
+	return aliases
 }
 
 func normalizeStorageAlias(input string) string {

--- a/wox.core/plugin/system/converter/core/storage_glossary_test.go
+++ b/wox.core/plugin/system/converter/core/storage_glossary_test.go
@@ -1,0 +1,121 @@
+package core
+
+import "testing"
+
+func TestResolveStorageUnit_ByteAliasesShareCanonicalUnit(t *testing.T) {
+	glossary := NewStorageGlossary()
+
+	aliases := []string{"b", "byte", "bytes"}
+	for _, alias := range aliases {
+		unit, ok := glossary.ResolveStorageUnit(alias)
+		if !ok {
+			t.Fatalf("expected alias %q to resolve", alias)
+		}
+		if unit.Symbol != "B" {
+			t.Fatalf("expected alias %q to resolve to symbol B, got %q", alias, unit.Symbol)
+		}
+		if unit.Family != StorageUnitFamilyByteBase {
+			t.Fatalf("expected alias %q to resolve to byte-base family, got %q", alias, unit.Family)
+		}
+	}
+}
+
+func TestResolveStorageUnit_GigabyteDisambiguationContract(t *testing.T) {
+	glossary := NewStorageGlossary()
+
+	gb, ok := glossary.ResolveStorageUnit("gb")
+	if !ok {
+		t.Fatalf("expected gb to resolve")
+	}
+	if gb.Symbol != "GB" || gb.Family != StorageUnitFamilyDecimal {
+		t.Fatalf("expected gb to resolve to decimal GB, got symbol=%q family=%q", gb.Symbol, gb.Family)
+	}
+
+	gib, ok := glossary.ResolveStorageUnit("gib")
+	if !ok {
+		t.Fatalf("expected gib to resolve")
+	}
+	if gib.Symbol != "GiB" || gib.Family != StorageUnitFamilyBinary {
+		t.Fatalf("expected gib to resolve to binary GiB, got symbol=%q family=%q", gib.Symbol, gib.Family)
+	}
+}
+
+func TestResolveStorageUnit_SymbolAndFullWordFormsAreEquivalent(t *testing.T) {
+	glossary := NewStorageGlossary()
+
+	cases := []struct {
+		symbol string
+		word   string
+	}{
+		{symbol: "GB", word: "gigabyte"},
+		{symbol: "MiB", word: "mebibyte"},
+	}
+
+	for _, tc := range cases {
+		symbolUnit, ok := glossary.ResolveStorageUnit(tc.symbol)
+		if !ok {
+			t.Fatalf("expected symbol %q to resolve", tc.symbol)
+		}
+		wordUnit, ok := glossary.ResolveStorageUnit(tc.word)
+		if !ok {
+			t.Fatalf("expected full-word %q to resolve", tc.word)
+		}
+
+		if symbolUnit != wordUnit {
+			t.Fatalf("expected %q and %q to resolve to same canonical unit, got %#v vs %#v", tc.symbol, tc.word, symbolUnit, wordUnit)
+		}
+	}
+}
+
+func TestResolveStorageUnit_NormalizationContract_TrimAndCaseInsensitive(t *testing.T) {
+	glossary := NewStorageGlossary()
+
+	cases := []struct {
+		input  string
+		symbol string
+		family StorageUnitFamily
+	}{
+		{input: "  BYTES  ", symbol: "B", family: StorageUnitFamilyByteBase},
+		{input: "\tGb\n", symbol: "GB", family: StorageUnitFamilyDecimal},
+		{input: "  giBiByTeS ", symbol: "GiB", family: StorageUnitFamilyBinary},
+	}
+
+	for _, tc := range cases {
+		unit, ok := glossary.ResolveStorageUnit(tc.input)
+		if !ok {
+			t.Fatalf("expected normalized input %q to resolve", tc.input)
+		}
+		if unit.Symbol != tc.symbol || unit.Family != tc.family {
+			t.Fatalf("expected input %q to resolve to symbol=%q family=%q, got symbol=%q family=%q", tc.input, tc.symbol, tc.family, unit.Symbol, unit.Family)
+		}
+	}
+}
+
+func TestResolveStorageUnit_SupportedRangeBoundary_IsExplicit(t *testing.T) {
+	glossary := NewStorageGlossary()
+
+	supported := []string{"b", "kb", "mb", "gb", "tb", "kib", "mib", "gib", "tib"}
+	for _, alias := range supported {
+		if _, ok := glossary.ResolveStorageUnit(alias); !ok {
+			t.Fatalf("expected supported alias %q to resolve", alias)
+		}
+	}
+
+	unsupportedBeyondBoundary := []string{"pb", "pib", "petabyte", "pebibyte"}
+	for _, alias := range unsupportedBeyondBoundary {
+		if _, ok := glossary.ResolveStorageUnit(alias); ok {
+			t.Fatalf("expected boundary alias %q to be unsupported", alias)
+		}
+	}
+}
+
+func TestResolveStorageUnit_Guardrails_UnsupportedOrAvoidTermsDoNotResolve(t *testing.T) {
+	glossary := NewStorageGlossary()
+
+	unsupported := []string{"", "bit", "bits", "kilobit", "kbit", "mbit", "byte/s"}
+	for _, term := range unsupported {
+		if _, ok := glossary.ResolveStorageUnit(term); ok {
+			t.Fatalf("expected unsupported/avoid term %q to not resolve", term)
+		}
+	}
+}

--- a/wox.core/plugin/system/converter/modules/units.go
+++ b/wox.core/plugin/system/converter/modules/units.go
@@ -15,6 +15,7 @@ type unitSpec struct {
 	unitType core.UnitType
 	singular string
 	plural   string
+	symbol   string
 	toBase   func(decimal.Decimal) decimal.Decimal
 	fromBase func(decimal.Decimal) decimal.Decimal
 }
@@ -296,6 +297,7 @@ func (m *UnitModule) registerStorageUnit(glossary core.StorageGlossary, symbol s
 		unitType: core.UnitTypeStorage,
 		singular: singular,
 		plural:   plural,
+		symbol:   symbol,
 		toBase: func(value decimal.Decimal) decimal.Decimal {
 			return value.Mul(factor)
 		},
@@ -364,7 +366,9 @@ func (m *UnitModule) formatValue(value decimal.Decimal, spec unitSpec) string {
 	}
 
 	unitName := spec.plural
-	if value.Abs().Equal(decimal.NewFromInt(1)) {
+	if spec.unitType == core.UnitTypeStorage {
+		unitName = spec.symbol
+	} else if value.Abs().Equal(decimal.NewFromInt(1)) {
 		unitName = spec.singular
 	}
 	return fmt.Sprintf("%s %s", displayText, unitName)
@@ -376,7 +380,7 @@ func storageUnitPattern(glossary core.StorageGlossary) string {
 	for _, alias := range aliases {
 		escapedAliases = append(escapedAliases, regexp.QuoteMeta(alias))
 	}
-	return `(?:` + strings.Join(escapedAliases, `|`) + `)`
+	return `(?i:(?:` + strings.Join(escapedAliases, `|`) + `))`
 }
 
 func normalizeUnitAlias(alias string) string {

--- a/wox.core/plugin/system/converter/modules/units.go
+++ b/wox.core/plugin/system/converter/modules/units.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"wox/plugin"
 	"wox/plugin/system/converter/core"
@@ -33,8 +34,9 @@ func NewUnitModule(ctx context.Context, api plugin.API) *UnitModule {
 		lengthUnits      = `(?:mm|millimeter|millimeters|cm|centimeter|centimeters|m|meter|meters|metre|metres|km|kilometer|kilometers|kilometre|kilometres|inch|inches|ft|foot|feet|yd|yard|yards|mi|mile|miles)`
 		weightUnits      = `(?:mg|milligram|milligrams|g|gram|grams|kg|kilogram|kilograms|oz|ounce|ounces|lb|lbs|pound|pounds|t|ton|tons)`
 		temperatureUnits = `(?:°?\s*c|celsius|centigrade|°?\s*f|fahrenheit|°?\s*k|kelvin)`
-		storageUnits     = `(?:b|byte|bytes)`
 	)
+	storageGlossary := core.NewStorageGlossary()
+	storageUnits := storageUnitPattern(storageGlossary)
 
 	// Length, weight, and temperature add single-letter aliases like "m", "g", and "c".
 	// Matching the whole conversion query avoids stealing those tokens from the existing
@@ -195,13 +197,15 @@ func NewUnitModule(ctx context.Context, api plugin.API) *UnitModule {
 			return value.Add(decimal.RequireFromString("273.15"))
 		},
 	)
-	m.registerLinearUnit(
-		[]string{"b", "byte", "bytes"},
-		core.UnitTypeStorage,
-		"byte",
-		"bytes",
-		decimal.NewFromInt(1),
-	)
+	m.registerStorageUnit(storageGlossary, "B", "byte", "bytes", decimal.NewFromInt(1))
+	m.registerStorageUnit(storageGlossary, "KB", "kilobyte", "kilobytes", decimal.NewFromInt(1000))
+	m.registerStorageUnit(storageGlossary, "MB", "megabyte", "megabytes", decimal.NewFromInt(1000000))
+	m.registerStorageUnit(storageGlossary, "GB", "gigabyte", "gigabytes", decimal.NewFromInt(1000000000))
+	m.registerStorageUnit(storageGlossary, "TB", "terabyte", "terabytes", decimal.NewFromInt(1000000000000))
+	m.registerStorageUnit(storageGlossary, "KiB", "kibibyte", "kibibytes", decimal.NewFromInt(1024))
+	m.registerStorageUnit(storageGlossary, "MiB", "mebibyte", "mebibytes", decimal.NewFromInt(1048576))
+	m.registerStorageUnit(storageGlossary, "GiB", "gibibyte", "gibibytes", decimal.NewFromInt(1073741824))
+	m.registerStorageUnit(storageGlossary, "TiB", "tebibyte", "tebibytes", decimal.NewFromInt(1099511627776))
 
 	return m
 }
@@ -286,6 +290,27 @@ func (m *UnitModule) registerLinearUnit(aliases []string, unitType core.UnitType
 	}
 }
 
+// registerStorageUnit registers all glossary aliases for one canonical storage unit.
+func (m *UnitModule) registerStorageUnit(glossary core.StorageGlossary, symbol string, singular string, plural string, factor decimal.Decimal) {
+	spec := unitSpec{
+		unitType: core.UnitTypeStorage,
+		singular: singular,
+		plural:   plural,
+		toBase: func(value decimal.Decimal) decimal.Decimal {
+			return value.Mul(factor)
+		},
+		fromBase: func(value decimal.Decimal) decimal.Decimal {
+			return value.Div(factor)
+		},
+	}
+	for _, alias := range glossary.Aliases() {
+		unit, ok := glossary.ResolveStorageUnit(alias)
+		if ok && unit.Symbol == symbol {
+			m.units[normalizeUnitAlias(alias)] = spec
+		}
+	}
+}
+
 func (m *UnitModule) registerTemperatureUnit(aliases []string, displayName string, toBase func(decimal.Decimal) decimal.Decimal, fromBase func(decimal.Decimal) decimal.Decimal) {
 	spec := unitSpec{
 		unitType: core.UnitTypeTemperature,
@@ -329,7 +354,7 @@ func (m *UnitModule) formatValue(value decimal.Decimal, spec unitSpec) string {
 	displayValue := value
 	if spec.unitType == core.UnitTypeLength {
 		displayValue = value.Round(3)
-	} else {
+	} else if spec.unitType != core.UnitTypeStorage {
 		displayValue = value.Round(2)
 	}
 	displayText := displayValue.StringFixedBank(int32(max(displayValue.Exponent()*-1, 0)))
@@ -343,6 +368,15 @@ func (m *UnitModule) formatValue(value decimal.Decimal, spec unitSpec) string {
 		unitName = spec.singular
 	}
 	return fmt.Sprintf("%s %s", displayText, unitName)
+}
+
+func storageUnitPattern(glossary core.StorageGlossary) string {
+	aliases := glossary.Aliases()
+	escapedAliases := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		escapedAliases = append(escapedAliases, regexp.QuoteMeta(alias))
+	}
+	return `(?:` + strings.Join(escapedAliases, `|`) + `)`
 }
 
 func normalizeUnitAlias(alias string) string {

--- a/wox.core/plugin/system/converter/modules/units.go
+++ b/wox.core/plugin/system/converter/modules/units.go
@@ -33,6 +33,7 @@ func NewUnitModule(ctx context.Context, api plugin.API) *UnitModule {
 		lengthUnits      = `(?:mm|millimeter|millimeters|cm|centimeter|centimeters|m|meter|meters|metre|metres|km|kilometer|kilometers|kilometre|kilometres|inch|inches|ft|foot|feet|yd|yard|yards|mi|mile|miles)`
 		weightUnits      = `(?:mg|milligram|milligrams|g|gram|grams|kg|kilogram|kilograms|oz|ounce|ounces|lb|lbs|pound|pounds|t|ton|tons)`
 		temperatureUnits = `(?:°?\s*c|celsius|centigrade|°?\s*f|fahrenheit|°?\s*k|kelvin)`
+		storageUnits     = `(?:b|byte|bytes)`
 	)
 
 	// Length, weight, and temperature add single-letter aliases like "m", "g", and "c".
@@ -57,6 +58,13 @@ func NewUnitModule(ctx context.Context, api plugin.API) *UnitModule {
 			Pattern:     numberPattern + `\s*(` + temperatureUnits + `)\s*(?:to|in|=\s*\?)\s*(` + temperatureUnits + `)`,
 			Priority:    1500,
 			Description: "Convert temperature units (e.g. 32f to c)",
+			Handler:     m.handleUnitConversion,
+			FullMatch:   true,
+		},
+		{
+			Pattern:     numberPattern + `\s*(` + storageUnits + `)\s*(?:to|in|=\s*\?)\s*(` + storageUnits + `)`,
+			Priority:    1500,
+			Description: "Convert byte aliases (e.g. 32 b to bytes)",
 			Handler:     m.handleUnitConversion,
 			FullMatch:   true,
 		},
@@ -186,6 +194,13 @@ func NewUnitModule(ctx context.Context, api plugin.API) *UnitModule {
 		func(value decimal.Decimal) decimal.Decimal {
 			return value.Add(decimal.RequireFromString("273.15"))
 		},
+	)
+	m.registerLinearUnit(
+		[]string{"b", "byte", "bytes"},
+		core.UnitTypeStorage,
+		"byte",
+		"bytes",
+		decimal.NewFromInt(1),
 	)
 
 	return m

--- a/wox.core/test/converter_test.go
+++ b/wox.core/test/converter_test.go
@@ -450,6 +450,45 @@ func TestConverterUnits(t *testing.T) {
 			ExpectedTitle:  "2 bytes",
 			ExpectedAction: "Copy",
 		},
+		{
+			Name:           "Storage decimal gigabyte family",
+			Query:          "32 bytes to gb",
+			ExpectedTitle:  "",
+			ExpectedAction: "Copy",
+			TitleCheck: func(title string) bool {
+				return strings.Contains(title, "0.000000032") && strings.Contains(title, "gigabytes") && !strings.Contains(title, "gibibytes")
+			},
+		},
+		{
+			Name:           "Storage binary gibibyte family",
+			Query:          "32 bytes to gib",
+			ExpectedTitle:  "",
+			ExpectedAction: "Copy",
+			TitleCheck: func(title string) bool {
+				return strings.Contains(title, "0.0000000298023224") && strings.Contains(title, "gibibytes")
+			},
+		},
+		{
+			Name:           "Storage gb ambiguity resolves to decimal bytes",
+			Query:          "1 gb to bytes",
+			ExpectedTitle:  "1000000000 bytes",
+			ExpectedAction: "Copy",
+		},
+		{
+			Name:           "Storage gib preserves binary bytes",
+			Query:          "1 gib to bytes",
+			ExpectedTitle:  "1073741824 bytes",
+			ExpectedAction: "Copy",
+		},
+		{
+			Name:           "Storage decimal to binary explicit control",
+			Query:          "1 gb to gib",
+			ExpectedTitle:  "",
+			ExpectedAction: "Copy",
+			TitleCheck: func(title string) bool {
+				return strings.Contains(title, "0.9313225746154785") && strings.Contains(title, "gibibytes")
+			},
+		},
 	}
 
 	suite.RunQueryTests(tests)

--- a/wox.core/test/converter_test.go
+++ b/wox.core/test/converter_test.go
@@ -407,6 +407,27 @@ func TestConverterBase(t *testing.T) {
 	suite.RunQueryTests(tests)
 }
 
+func TestConverterStorageQueryIntentParity(t *testing.T) {
+	suite := NewTestSuite(t)
+
+	tests := []QueryTest{
+		{
+			Name:           "Equals-question syntax converts bytes to decimal gigabytes",
+			Query:          "32 bytes =? gb",
+			ExpectedTitle:  "0.000000032 gigabytes",
+			ExpectedAction: "Copy",
+		},
+		{
+			Name:           "Equals-question syntax converts compact bytes to decimal gigabytes",
+			Query:          "32bytes =? gb",
+			ExpectedTitle:  "0.000000032 gigabytes",
+			ExpectedAction: "Copy",
+		},
+	}
+
+	suite.RunQueryTests(tests)
+}
+
 func TestConverterUnits(t *testing.T) {
 	suite := NewTestSuite(t)
 

--- a/wox.core/test/converter_test.go
+++ b/wox.core/test/converter_test.go
@@ -412,15 +412,21 @@ func TestConverterStorageQueryIntentParity(t *testing.T) {
 
 	tests := []QueryTest{
 		{
-			Name:           "Equals-question syntax converts bytes to decimal gigabytes",
-			Query:          "32 bytes =? gb",
-			ExpectedTitle:  "0.000000032 gigabytes",
+			Name:           "To conversion syntax parses Byte base unit to Decimal storage unit",
+			Query:          "32 bytes to gb",
+			ExpectedTitle:  "0.000000032 GB",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Equals-question syntax converts compact bytes to decimal gigabytes",
+			Name:           "Equals-question conversion syntax matches Decimal storage unit output",
+			Query:          "32 bytes =? gb",
+			ExpectedTitle:  "0.000000032 GB",
+			ExpectedAction: "Copy",
+		},
+		{
+			Name:           "Compact byte input parses with equals-question conversion syntax",
 			Query:          "32bytes =? gb",
-			ExpectedTitle:  "0.000000032 gigabytes",
+			ExpectedTitle:  "0.000000032 GB",
 			ExpectedAction: "Copy",
 		},
 	}
@@ -454,46 +460,43 @@ func TestConverterUnits(t *testing.T) {
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage full-word input renders symbol output",
+			Name:           "Storage Unit full-word form renders Unit symbol form output",
 			Query:          "1 gigabyte to gibibyte",
 			ExpectedTitle:  "0.9313225746154785 GiB",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage uppercase symbol input renders symbol output",
+			Name:           "Storage Unit symbol form renders Unit symbol form output",
 			Query:          "1 GB to MiB",
 			ExpectedTitle:  "953.67431640625 MiB",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage byte symbol to word alias",
+			Name:           "Storage Byte base unit symbol alias renders symbolized output",
 			Query:          "32 b to bytes",
 			ExpectedTitle:  "32 B",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage byte singular to symbol alias",
+			Name:           "Storage Byte base unit singular alias renders symbolized output",
 			Query:          "1 byte to b",
 			ExpectedTitle:  "1 B",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage byte plural to singular alias",
+			Name:           "Storage Byte base unit plural alias renders symbolized output",
 			Query:          "2 bytes to byte",
 			ExpectedTitle:  "2 B",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage decimal gigabyte family",
+			Name:           "Storage Decimal storage unit uses GB output",
 			Query:          "32 bytes to gb",
-			ExpectedTitle:  "",
+			ExpectedTitle:  "0.000000032 GB",
 			ExpectedAction: "Copy",
-			TitleCheck: func(title string) bool {
-				return strings.Contains(title, "0.000000032") && strings.Contains(title, "GB") && !strings.Contains(title, "GiB")
-			},
 		},
 		{
-			Name:           "Storage binary gibibyte family",
+			Name:           "Storage Binary storage unit uses GiB output",
 			Query:          "32 bytes to gib",
 			ExpectedTitle:  "",
 			ExpectedAction: "Copy",
@@ -502,25 +505,22 @@ func TestConverterUnits(t *testing.T) {
 			},
 		},
 		{
-			Name:           "Storage gb ambiguity resolves to decimal bytes",
+			Name:           "Storage gb ambiguity resolves to Decimal storage unit bytes",
 			Query:          "1 gb to bytes",
 			ExpectedTitle:  "1000000000 B",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage gib preserves binary bytes",
+			Name:           "Storage gib preserves Binary storage unit bytes",
 			Query:          "1 gib to bytes",
 			ExpectedTitle:  "1073741824 B",
 			ExpectedAction: "Copy",
 		},
 		{
-			Name:           "Storage decimal to binary explicit control",
+			Name:           "Storage Decimal to Binary storage unit explicit control",
 			Query:          "1 gb to gib",
-			ExpectedTitle:  "",
+			ExpectedTitle:  "0.9313225746154785 GiB",
 			ExpectedAction: "Copy",
-			TitleCheck: func(title string) bool {
-				return strings.Contains(title, "0.9313225746154785") && strings.Contains(title, "GiB")
-			},
 		},
 	}
 

--- a/wox.core/test/converter_test.go
+++ b/wox.core/test/converter_test.go
@@ -432,6 +432,24 @@ func TestConverterUnits(t *testing.T) {
 			ExpectedTitle:  "0 celsius",
 			ExpectedAction: "Copy",
 		},
+		{
+			Name:           "Storage byte symbol to word alias",
+			Query:          "32 b to bytes",
+			ExpectedTitle:  "32 bytes",
+			ExpectedAction: "Copy",
+		},
+		{
+			Name:           "Storage byte singular to symbol alias",
+			Query:          "1 byte to b",
+			ExpectedTitle:  "1 byte",
+			ExpectedAction: "Copy",
+		},
+		{
+			Name:           "Storage byte plural to singular alias",
+			Query:          "2 bytes to byte",
+			ExpectedTitle:  "2 bytes",
+			ExpectedAction: "Copy",
+		},
 	}
 
 	suite.RunQueryTests(tests)

--- a/wox.core/test/converter_test.go
+++ b/wox.core/test/converter_test.go
@@ -454,21 +454,33 @@ func TestConverterUnits(t *testing.T) {
 			ExpectedAction: "Copy",
 		},
 		{
+			Name:           "Storage full-word input renders symbol output",
+			Query:          "1 gigabyte to gibibyte",
+			ExpectedTitle:  "0.9313225746154785 GiB",
+			ExpectedAction: "Copy",
+		},
+		{
+			Name:           "Storage uppercase symbol input renders symbol output",
+			Query:          "1 GB to MiB",
+			ExpectedTitle:  "953.67431640625 MiB",
+			ExpectedAction: "Copy",
+		},
+		{
 			Name:           "Storage byte symbol to word alias",
 			Query:          "32 b to bytes",
-			ExpectedTitle:  "32 bytes",
+			ExpectedTitle:  "32 B",
 			ExpectedAction: "Copy",
 		},
 		{
 			Name:           "Storage byte singular to symbol alias",
 			Query:          "1 byte to b",
-			ExpectedTitle:  "1 byte",
+			ExpectedTitle:  "1 B",
 			ExpectedAction: "Copy",
 		},
 		{
 			Name:           "Storage byte plural to singular alias",
 			Query:          "2 bytes to byte",
-			ExpectedTitle:  "2 bytes",
+			ExpectedTitle:  "2 B",
 			ExpectedAction: "Copy",
 		},
 		{
@@ -477,7 +489,7 @@ func TestConverterUnits(t *testing.T) {
 			ExpectedTitle:  "",
 			ExpectedAction: "Copy",
 			TitleCheck: func(title string) bool {
-				return strings.Contains(title, "0.000000032") && strings.Contains(title, "gigabytes") && !strings.Contains(title, "gibibytes")
+				return strings.Contains(title, "0.000000032") && strings.Contains(title, "GB") && !strings.Contains(title, "GiB")
 			},
 		},
 		{
@@ -486,19 +498,19 @@ func TestConverterUnits(t *testing.T) {
 			ExpectedTitle:  "",
 			ExpectedAction: "Copy",
 			TitleCheck: func(title string) bool {
-				return strings.Contains(title, "0.0000000298023224") && strings.Contains(title, "gibibytes")
+				return strings.Contains(title, "0.0000000298023224") && strings.Contains(title, "GiB")
 			},
 		},
 		{
 			Name:           "Storage gb ambiguity resolves to decimal bytes",
 			Query:          "1 gb to bytes",
-			ExpectedTitle:  "1000000000 bytes",
+			ExpectedTitle:  "1000000000 B",
 			ExpectedAction: "Copy",
 		},
 		{
 			Name:           "Storage gib preserves binary bytes",
 			Query:          "1 gib to bytes",
-			ExpectedTitle:  "1073741824 bytes",
+			ExpectedTitle:  "1073741824 B",
 			ExpectedAction: "Copy",
 		},
 		{
@@ -507,7 +519,7 @@ func TestConverterUnits(t *testing.T) {
 			ExpectedTitle:  "",
 			ExpectedAction: "Copy",
 			TitleCheck: func(title string) bool {
-				return strings.Contains(title, "0.9313225746154785") && strings.Contains(title, "gibibytes")
+				return strings.Contains(title, "0.9313225746154785") && strings.Contains(title, "GiB")
 			},
 		},
 	}

--- a/www/docs/guide/plugins/system/converter.md
+++ b/www/docs/guide/plugins/system/converter.md
@@ -7,7 +7,9 @@ Converter handles units, currencies, crypto prices, number bases, dates, time zo
 ```text
 1km to m
 100lb to kg
-255 to hex
+32 bytes to gb
+32bytes =? gb
+1 GB to MiB
 1 btc to usd
 100 usd + 50 usd
 ```
@@ -27,9 +29,24 @@ Converter listens globally. Use `calculator` as an explicit keyword if another g
 | Time | timestamps, dates, durations, and time zones |
 | Math | `+`, `-`, `*`, `/` with compatible values |
 
+## Storage Conversion Language
+
+Storage queries use `B` as the Byte base unit, decimal units such as `GB` for base-1000 storage, and binary units such as `GiB` or `MiB` for base-1024 storage. Unit symbol form (`GB`, `MiB`) and Unit full-word form (`gigabyte`, `mebibyte`) are both accepted; results use Unit symbol form.
+
+| Acceptance scenario | Query | Expected result |
+| --- | --- | --- |
+| Decimal storage unit from Byte base unit | `32 bytes to gb` | `0.000000032 GB` |
+| Binary storage unit from Byte base unit | `32 bytes to gib` | `0.0000000298023224 GiB` |
+| Equals-question conversion syntax | `32 bytes =? gb` | `0.000000032 GB` |
+| Compact byte input | `32bytes =? gb` | `0.000000032 GB` |
+| Unit symbol form | `1 GB to MiB` | `953.67431640625 MiB` |
+| Unit full-word form | `1 gigabyte to gibibyte` | `0.9313225746154785 GiB` |
+| Byte aliases render as symbol output | `32 b to bytes` | `32 B` |
+
 ## Tips
 
-- Use `to` or `in` to make the target unit explicit.
+- Use `to`, `in`, or `=?` to make conversion intent explicit.
+- For storage conversion, `gb` means Decimal storage unit `GB`; use `gib` for Binary storage unit `GiB`.
 - Base conversion expects an integer and a target base.
 - Currency and crypto rates refresh in the background and may use cached values while offline.
 - Set your default currency in plugin settings if fallback conversions are not what you expect.

--- a/www/docs/zh/guide/plugins/system/converter.md
+++ b/www/docs/zh/guide/plugins/system/converter.md
@@ -7,7 +7,9 @@
 ```text
 1km to m
 100lb to kg
-255 to hex
+32 bytes to gb
+32bytes =? gb
+1 GB to MiB
 1 btc to usd
 100 usd + 50 usd
 ```
@@ -27,9 +29,24 @@
 | 时间 | 时间戳、日期、时长、时区 |
 | 计算 | 对兼容值使用 `+`、`-`、`*`、`/` |
 
+## 存储转换语言
+
+存储查询使用 `B` 作为 Byte base unit，`GB` 等 Decimal storage unit 表示 base-1000 存储，`GiB`、`MiB` 等 Binary storage unit 表示 base-1024 存储。Unit symbol form（`GB`、`MiB`）和 Unit full-word form（`gigabyte`、`mebibyte`）都可作为输入；结果使用 Unit symbol form。
+
+| 验收场景 | 查询 | 预期结果 |
+| --- | --- | --- |
+| 从 Byte base unit 转为 Decimal storage unit | `32 bytes to gb` | `0.000000032 GB` |
+| 从 Byte base unit 转为 Binary storage unit | `32 bytes to gib` | `0.0000000298023224 GiB` |
+| Equals-question conversion syntax | `32 bytes =? gb` | `0.000000032 GB` |
+| Compact byte input | `32bytes =? gb` | `0.000000032 GB` |
+| Unit symbol form | `1 GB to MiB` | `953.67431640625 MiB` |
+| Unit full-word form | `1 gigabyte to gibibyte` | `0.9313225746154785 GiB` |
+| Byte aliases 使用 symbolized output | `32 b to bytes` | `32 B` |
+
 ## 技巧
 
-- 使用 `to` 或 `in` 明确目标单位。
+- 使用 `to`、`in` 或 `=?` 明确转换意图。
+- 存储转换中，`gb` 表示 Decimal storage unit `GB`；如需 Binary storage unit `GiB`，请使用 `gib`。
 - 进制转换需要整数和目标进制。
 - 货币和加密货币汇率会在后台刷新，离线时可能使用缓存值。
 - 如果 fallback 转换的目标货币不符合预期，在插件设置中修改默认货币。


### PR DESCRIPTION
## Summary
- Add a canonical storage glossary for byte aliases and decimal/binary storage families.
- Support storage conversions across `to` and `=?`, symbol/full-word inputs, and symbolized output.
- Document storage conversion acceptance scenarios in English and Chinese converter docs.

## Test plan
- [x] `cd wox.core && go test -count=1 ./plugin/system/converter/core`
- [ ] Run broader converter integration tests in an environment with required embedded resources and desktop dependencies.
- [ ] Build Windows/Linux/macOS artifacts via the existing CI build workflow.