### PR TITLE
Fix Windows OpenFileInFolder PowerShell path injection risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fix
   - [`Screenshot`] Fix permission-denied capture feedback with localized notifications #4433
   - [`Hotkey`] Fix arrow-key hotkey recognition when alternate key names are reported by the platform.
-
+  - [`Security`] Fix Windows file reveal behavior to use the Windows Shell API instead of interpolated PowerShell command text, preventing crafted file paths from being interpreted as commands when opening a file's containing folder.
 
 ## v2.1.1 - 2026-05-24
 

--- a/wox.core/util/shell/shell_windows.go
+++ b/wox.core/util/shell/shell_windows.go
@@ -1,13 +1,30 @@
 package shell
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
+	"unsafe"
 	"wox/util"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	coInitializeAlreadyInitialized = syscall.Errno(1)
+	coInitializeChangedMode        = syscall.Errno(0x80010106)
+)
+
+var (
+	shell32                        = windows.NewLazySystemDLL("shell32.dll")
+	procILCreateFromPathW          = shell32.NewProc("ILCreateFromPathW")
+	procILFree                     = shell32.NewProc("ILFree")
+	procSHOpenFolderAndSelectItems = shell32.NewProc("SHOpenFolderAndSelectItems")
 )
 
 func Open(path string) error {
@@ -53,9 +70,65 @@ func OpenFileInFolder(path string) error {
 		return err
 	}
 
-	powershellCmd := fmt.Sprintf("Start-Process \"explorer.exe\" -ArgumentList \"/select,%s\"", absPath)
-	_, err = Run("powershell.exe", "-Command", powershellCmd)
-	return err
+	return openFileInFolder(absPath)
+}
+
+// openFileInFolder asks Windows Shell to reveal the item directly instead of
+// relying on explorer.exe command-line parsing.
+func openFileInFolder(path string) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	cleanupCOM, err := initializeCOMForShell()
+	if err != nil {
+		return err
+	}
+	defer cleanupCOM()
+
+	itemIDList, err := createShellItemIDList(path)
+	if err != nil {
+		return err
+	}
+	defer procILFree.Call(itemIDList)
+
+	ret, _, _ := procSHOpenFolderAndSelectItems.Call(itemIDList, 0, 0, 0)
+	if ret != 0 {
+		return fmt.Errorf("open folder and select item failed with HRESULT 0x%08x", uint32(ret))
+	}
+
+	return nil
+}
+
+// initializeCOMForShell prepares COM for Shell API calls when this goroutine
+// has not already entered a COM apartment.
+func initializeCOMForShell() (func(), error) {
+	err := windows.CoInitializeEx(0, windows.COINIT_APARTMENTTHREADED|windows.COINIT_DISABLE_OLE1DDE)
+	if err == nil || errors.Is(err, coInitializeAlreadyInitialized) {
+		return windows.CoUninitialize, nil
+	}
+	if errors.Is(err, coInitializeChangedMode) {
+		return func() {}, nil
+	}
+	return nil, fmt.Errorf("initialize COM for Shell API: %w", err)
+}
+
+// createShellItemIDList converts a filesystem path to the Shell item ID list
+// required by SHOpenFolderAndSelectItems.
+func createShellItemIDList(path string) (uintptr, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("encode Shell path: %w", err)
+	}
+
+	itemIDList, _, callErr := procILCreateFromPathW.Call(uintptr(unsafe.Pointer(pathPtr)))
+	if itemIDList == 0 {
+		if callErr != syscall.Errno(0) {
+			return 0, fmt.Errorf("create Shell item ID list: %w", callErr)
+		}
+		return 0, fmt.Errorf("create Shell item ID list failed")
+	}
+
+	return itemIDList, nil
 }
 
 // HideWindowCmd sets the SysProcAttr to hide the console window on Windows

--- a/wox.core/util/shell/shell_windows_test.go
+++ b/wox.core/util/shell/shell_windows_test.go
@@ -1,0 +1,39 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateShellItemIDListHandlesSpecialPathCharacters(t *testing.T) {
+	rootPath := t.TempDir()
+	filePath := filepath.Join(rootPath, `$(Start-Process calc)& space dir`, `file $(Start-Process calc)& name.txt`)
+	mustMkdirAll(t, filepath.Dir(filePath))
+	mustWriteTestFile(t, filePath)
+
+	itemIDList, err := createShellItemIDList(filePath)
+	if err != nil {
+		t.Fatalf("create Shell item ID list: %v", err)
+	}
+	if itemIDList == 0 {
+		t.Fatal("expected non-zero Shell item ID list")
+	}
+	procILFree.Call(itemIDList)
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", path, err)
+	}
+}
+
+func mustWriteTestFile(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte("wox shell test"), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace Windows `OpenFileInFolder` PowerShell command-string construction with the Windows Shell API (`SHOpenFolderAndSelectItems`).
- Convert the filesystem path to a Shell ITEMIDLIST with `ILCreateFromPathW`, initialize COM on a locked OS thread, and let Shell reveal/select the item directly.
- Add a focused Windows regression test for paths containing spaces and PowerShell/cmd metacharacters.
- Rebase onto the latest `master` and resolve the `CHANGELOG.md` conflict by placing the security entry under the existing `v2.1.2` `Fix` section.

## Root Cause
The previous PR version removed PowerShell interpolation but still relied on `explorer.exe /select` command-line parsing. That parsing is not robust enough across environments for paths containing spaces or special characters. The final version bypasses Explorer command-line parsing entirely and calls the Shell selection API directly.

## Security Impact
Before this PR, `OpenFileInFolder` interpolated an absolute file path into a PowerShell command string. A crafted path containing PowerShell metacharacters such as `$()` could be interpreted as script text while Wox tried to reveal the file.

The new implementation treats the path as data passed to Windows Shell APIs, not as command text.

## Changelog
- [`Security`] Fix Windows file reveal behavior to use the Windows Shell API instead of interpolated PowerShell command text, preventing crafted file paths from being interpreted as commands when opening a file's containing folder.

## Verification
- `go test ./util/shell -count=1`
- Local Windows behavior verification with a temporary Go harness calling `shell.OpenFileInFolder`, then checking Explorer selection through `Shell.Application` COM for:
  - normal path
  - path with spaces
  - path with PowerShell/cmd metacharacters: `$(Start-Process calc)&`
  - path with single-quote punctuation
- Confirmed no new `calc` / `CalculatorApp` process was started for the metacharacter path.