### PR TITLE
feat: add backquote/tilde key hotkey support across all platforms

### DIFF
--- a/wox.core/util/keyboard/keyboard_linux.go
+++ b/wox.core/util/keyboard/keyboard_linux.go
@@ -309,6 +309,8 @@ func keyToEvdevKeyCode(key Key) (uint16, error) {
 		return 125, nil
 	case KeyCapsLock:
 		return 58, nil
+	case KeyBackquote:
+		return 87, nil
 	default:
 		return 0, fmt.Errorf("no evdev key code for key: %d", key)
 	}

--- a/wox.core/util/keyboard/listener.go
+++ b/wox.core/util/keyboard/listener.go
@@ -81,6 +81,8 @@ const (
 	KeyF11
 	KeyF12
 	KeyCapsLock
+	// KeyBackquote represents the backquote/tilde key (` ~).
+	KeyBackquote
 	// KeyCtrl is Control on all supported platforms.
 	KeyCtrl
 	// KeyShift is Shift on all supported platforms.
@@ -210,6 +212,8 @@ func ParseKey(token string) (Key, error) {
 		return KeyF12, nil
 	case "capslock", "caps_lock", "caps lock":
 		return KeyCapsLock, nil
+	case "backquote", "tilde", "~", "`":
+		return KeyBackquote, nil
 	default:
 		return KeyUnknown, fmt.Errorf("invalid key: %s", token)
 	}
@@ -289,6 +293,8 @@ func (k Key) Character() string {
 		return "8"
 	case Key9:
 		return "9"
+	case KeyBackquote:
+		return "~"
 	default:
 		return ""
 	}

--- a/wox.core/util/keyboard/listener_darwin.go
+++ b/wox.core/util/keyboard/listener_darwin.go
@@ -353,6 +353,8 @@ func keyToDarwinKeyCode(key Key) (uint32, error) {
 		return 111, nil
 	case KeyCapsLock:
 		return 57, nil
+	case KeyBackquote:
+		return 50, nil
 	default:
 		return 0, fmt.Errorf("unsupported macOS hotkey key: %d", key)
 	}
@@ -484,6 +486,8 @@ func darwinKeyCodeToKey(keyCode uint32) Key {
 		return KeyAlt
 	case 59, 62:
 		return KeyCtrl
+	case 50:
+		return KeyBackquote
 	default:
 		return KeyUnknown
 	}

--- a/wox.core/util/keyboard/listener_linux_wayland.go
+++ b/wox.core/util/keyboard/listener_linux_wayland.go
@@ -713,6 +713,8 @@ func keyToWaylandTriggerName(key Key) (string, error) {
 		return "F12", nil
 	case KeyCapsLock:
 		return "Caps_Lock", nil
+	case KeyBackquote:
+		return "grave", nil
 	default:
 		return "", fmt.Errorf("unsupported Wayland hotkey key: %d", key)
 	}

--- a/wox.core/util/keyboard/listener_linux_x11.go
+++ b/wox.core/util/keyboard/listener_linux_x11.go
@@ -335,6 +335,8 @@ func keyToLinuxKeyCode(key Key) (uint32, error) {
 		return 0xFFC9, nil
 	case KeyCapsLock:
 		return 0xFFE5, nil
+	case KeyBackquote:
+		return 0x0060, nil
 	default:
 		return 0, fmt.Errorf("unsupported Linux hotkey key: %d", key)
 	}
@@ -466,6 +468,8 @@ func linuxKeyCodeToKey(code uint32) Key {
 		return KeyAlt
 	case 0xFFEB, 0xFFEC:
 		return KeySuper
+	case 0x0060:
+		return KeyBackquote
 	default:
 		return KeyUnknown
 	}

--- a/wox.core/util/keyboard/listener_windows.go
+++ b/wox.core/util/keyboard/listener_windows.go
@@ -327,6 +327,8 @@ func keyToWindowsVK(key Key) (uint32, error) {
 		return 0x7B, nil
 	case KeyCapsLock:
 		return 0x14, nil
+	case KeyBackquote:
+		return 0xC0, nil
 	default:
 		return 0, fmt.Errorf("unsupported Windows hotkey key: %d", key)
 	}
@@ -458,6 +460,8 @@ func windowsVKToKey(vkCode uint32) Key {
 		return KeyAlt
 	case 0x5B, 0x5C:
 		return KeySuper
+	case 0xC0:
+		return KeyBackquote
 	default:
 		return KeyUnknown
 	}

--- a/wox.ui.flutter/wox/lib/entity/wox_hotkey.dart
+++ b/wox.ui.flutter/wox/lib/entity/wox_hotkey.dart
@@ -210,6 +210,8 @@ class WoxHotkey {
         key = LogicalKeyboardKey.tab;
       } else if (e == "capslock") {
         key = LogicalKeyboardKey.capsLock;
+      } else if (e == "backquote" || e == "tilde" || e == "~" || e == "`") {
+        key = LogicalKeyboardKey.backquote;
       } else if (e == "shiftleft") {
         key = LogicalKeyboardKey.shiftLeft;
       } else if (e == "shiftright") {
@@ -368,6 +370,7 @@ class WoxHotkey {
       PhysicalKeyboardKey.arrowDown,
       PhysicalKeyboardKey.arrowRight,
       PhysicalKeyboardKey.arrowUp,
+      PhysicalKeyboardKey.backquote,
     ];
 
     return allowedKeys.contains(key);
@@ -443,6 +446,7 @@ class WoxHotkey {
       PhysicalKeyboardKey.controlLeft || PhysicalKeyboardKey.controlRight => "Control",
       PhysicalKeyboardKey.altLeft || PhysicalKeyboardKey.altRight => "Alt",
       PhysicalKeyboardKey.metaLeft || PhysicalKeyboardKey.metaRight => "Meta",
+      PhysicalKeyboardKey.backquote => "~",
       _ => null,
     };
   }
@@ -507,6 +511,8 @@ class WoxHotkey {
       keyStr = "right";
     } else if (key == PhysicalKeyboardKey.arrowUp || key == LogicalKeyboardKey.arrowUp) {
       keyStr = "up";
+    } else if (key == PhysicalKeyboardKey.backquote || key == LogicalKeyboardKey.backquote) {
+      keyStr = "~";
     }
     return keyStr;
   }

--- a/wox.ui.flutter/wox/lib/utils/wox_hotkey_display_util.dart
+++ b/wox.ui.flutter/wox/lib/utils/wox_hotkey_display_util.dart
@@ -55,6 +55,8 @@ class WoxHotkeyDisplayUtil {
       return "Pause";
     } else if (key == LogicalKeyboardKey.printScreen) {
       return "PrintScreen";
+    } else if (key == LogicalKeyboardKey.backquote || key == PhysicalKeyboardKey.backquote) {
+      return "~";
     }
 
     final label = key.keyLabel;
@@ -159,6 +161,7 @@ class WoxHotkeyDisplayUtil {
       "backspace" => "Backspace",
       "delete" => "Delete",
       "tab" => "Tab",
+      "backquote" || "tilde" => "~",
       "arrowup" || "up" => "↑",
       "arrowdown" || "down" => "↓",
       "arrowleft" || "left" => "←",


### PR DESCRIPTION
## Summary

Add support for the backquote/tilde key (\ ~) as a hotkey across all supported platforms.

## Changes

### Go Backend
- Added \KeyBackquote\ constant to the key enum
- Added parsing support for \ackquote\, \	ilde\, \~\, and \\\\ tokens
- Added platform-specific key code mappings:
  - **Linux**: evdev key code 87
  - **macOS**: virtual key code 50
  - **Windows**: virtual key code 0xC0
  - **Linux X11**: X11 key code 0x0060
  - **Linux Wayland**: trigger name \grave\

### Flutter UI
- Added backquote key handling in \WoxHotkey\ entity
- Added display mapping showing \~\ for the backquote key
- Added backquote to the allowed hotkey keys list

## Closes #4456