### PR TITLE
feat: add VSCode Projects script plugin

### DIFF
--- a/store-plugin.json
+++ b/store-plugin.json
@@ -895,7 +895,7 @@
     "Id": "c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f",
     "Name": "VSCode Projects",
     "Author": "hopsiedev",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "MinWoxVersion": "2.0.0",
     "Runtime": "script",
     "Description": "Quickly create, open and manage your VSCode projects",
@@ -903,7 +903,7 @@
     "Website": "https://github.com/hopsiedev/Wox.Plugin.VSCodeProjects",
     "DownloadUrl": "https://raw.githubusercontent.com/hopsiedev/Wox.Plugin.VSCodeProjects/main/Wox.Plugin.Script.VSCodeProjects.py",
     "ScreenshotUrls": [
-      "https://raw.githubusercontent.com/hopsiedev/Wox.Plugin.VSCodeProjects/main/preview.svg"
+      "https://raw.githubusercontent.com/hopsiedev/Wox.Plugin.VSCodeProjects/main/preview.png"
     ],
     "SupportedOS": [
       "Windows",

--- a/store-plugin.json
+++ b/store-plugin.json
@@ -890,5 +890,27 @@
         "plugin_description": "查看 FIFA 2026 世界杯赛程、赛果和实时比分。"
       }
     }
+  },
+  {
+    "Id": "c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f",
+    "Name": "VSCode Projects",
+    "Author": "hopsiedev",
+    "Version": "1.0.0",
+    "MinWoxVersion": "2.0.0",
+    "Runtime": "script",
+    "Description": "Quickly create, open and manage your VSCode projects",
+    "IconEmoji": "💻",
+    "Website": "https://github.com/hopsiedev/Wox.Plugin.VSCodeProjects",
+    "DownloadUrl": "https://raw.githubusercontent.com/hopsiedev/Wox.Plugin.VSCodeProjects/main/Wox.Plugin.Script.VSCodeProjects.py",
+    "ScreenshotUrls": [
+      "https://raw.githubusercontent.com/hopsiedev/Wox.Plugin.VSCodeProjects/main/preview.svg"
+    ],
+    "SupportedOS": [
+      "Windows",
+      "Darwin",
+      "Linux"
+    ],
+    "DateCreated": "2026-06-26 00:00:00",
+    "DateUpdated": "2026-06-26 00:00:00"
   }
 ]


### PR DESCRIPTION
Adds VSCode Projects — a script plugin to create, open, and manage VSCode projects from Wox using the `vsc` keyword.

- Trigger: `vsc`
- Runtime: script (Python)  
- OS: Windows, Darwin, Linux
- Repo: https://github.com/hopsiedev/Wox.Plugin.VSCodeProjects