### PR TITLE
Add need plugin to store

### DIFF
--- a/store-plugin.json
+++ b/store-plugin.json
@@ -936,19 +936,19 @@
     "Id": "d30c9661-fa55-4ea6-b6f1-bc61e7aa8586",
     "Name": "need",
     "Author": "zed",
-    "Version": "0.1.0",
-    "MinWoxVersion": "2.0.0",
-    "Runtime": "script",
+    "Version": "0.2.0",
+    "MinWoxVersion": "2.0.4",
+    "Runtime": "nodejs",
     "Description": "Store and quickly retrieve local key-value notes",
     "IconEmoji": "📌",
     "Website": "https://github.com/zzedbot/wox-plugin-need",
-    "DownloadUrl": "https://raw.githubusercontent.com/zzedbot/wox-plugin-need/v0.1.0/Wox.Plugin.Script.Need.js",
+    "DownloadUrl": "https://github.com/zzedbot/wox-plugin-need/releases/latest/download/wox.plugin.need.wox",
     "SupportedOS": [
       "Windows",
       "Darwin",
       "Linux"
     ],
     "DateCreated": "2026-08-28 21:27:52",
-    "DateUpdated": "2026-08-28 21:27:52"
+    "DateUpdated": "2026-08-29 10:51:00"
   }
 ]

--- a/store-plugin.json
+++ b/store-plugin.json
@@ -943,6 +943,10 @@
     "IconEmoji": "📌",
     "Website": "https://github.com/zzedbot/wox-plugin-need",
     "DownloadUrl": "https://github.com/zzedbot/wox-plugin-need/releases/latest/download/wox.plugin.need.wox",
+    "ScreenshotUrls": [
+      "https://raw.githubusercontent.com/zzedbot/wox-plugin-need/main/screenshots/createkey.png",
+      "https://raw.githubusercontent.com/zzedbot/wox-plugin-need/main/screenshots/searchkey.png"
+    ],
     "SupportedOS": [
       "Windows",
       "Darwin",

--- a/store-plugin.json
+++ b/store-plugin.json
@@ -931,5 +931,24 @@
     ],
     "DateCreated": "2026-07-25 02:10:59",
     "DateUpdated": "2026-07-25 21:17:02"
+  },
+  {
+    "Id": "d30c9661-fa55-4ea6-b6f1-bc61e7aa8586",
+    "Name": "need",
+    "Author": "zed",
+    "Version": "0.1.0",
+    "MinWoxVersion": "2.0.0",
+    "Runtime": "script",
+    "Description": "Store and quickly retrieve local key-value notes",
+    "IconEmoji": "📌",
+    "Website": "https://github.com/zzedbot/wox-plugin-need",
+    "DownloadUrl": "https://raw.githubusercontent.com/zzedbot/wox-plugin-need/v0.1.0/Wox.Plugin.Script.Need.js",
+    "SupportedOS": [
+      "Windows",
+      "Darwin",
+      "Linux"
+    ],
+    "DateCreated": "2026-08-28 21:27:52",
+    "DateUpdated": "2026-08-28 21:27:52"
   }
 ]


### PR DESCRIPTION
## Summary

- Add `need` to the Wox plugin store.
- Publish version `0.2.0` as a standard Node.js SDK plugin.
- Use the GitHub Release `.wox` package as the store download.
- Include screenshots for creating and searching key-value notes.

## Plugin

- Repository: https://github.com/zzedbot/wox-plugin-need
- Release: https://github.com/zzedbot/wox-plugin-need/releases/tag/v0.2.0
- Runtime: `nodejs`
- Minimum Wox version: `2.0.4`
- Supported OS: Windows, macOS, Linux

## Screenshots

### Create a key-value note

![Create a key-value note](https://raw.githubusercontent.com/zzedbot/wox-plugin-need/main/screenshots/createkey.png)

### Search a key-value note

![Search a key-value note](https://raw.githubusercontent.com/zzedbot/wox-plugin-need/main/screenshots/searchkey.png)

## Verification

- Both screenshot URLs return HTTP 200 with `image/png` content.
- The release asset URL returns HTTP 200.
- The packaged plugin was installed and tested locally in Wox.
- Automated tests cover create/search/copy, legacy data compatibility, and backup recovery.