### PR TITLE
Update need to 0.2.1

### DIFF
--- a/store-plugin.json
+++ b/store-plugin.json
@@ -936,7 +936,7 @@
     "Id": "d30c9661-fa55-4ea6-b6f1-bc61e7aa8586",
     "Name": "need",
     "Author": "zed",
-    "Version": "0.2.0",
+    "Version": "0.2.1",
     "MinWoxVersion": "2.0.4",
     "Runtime": "nodejs",
     "Description": "Store and quickly retrieve local key-value notes",
@@ -953,7 +953,7 @@
       "Linux"
     ],
     "DateCreated": "2026-08-28 21:27:52",
-    "DateUpdated": "2026-08-29 10:51:00"
+    "DateUpdated": "2026-09-03 16:39:00"
   },
   {
     "Id": "5e693e9d-4683-4982-8929-d4ea5e364c5b",


### PR DESCRIPTION
## Summary

- Update `need` from `0.2.0` to `0.2.1`.
- Fix copying the last matched value instead of the selected result when multiple results are shown.
- Keep the existing latest-release download URL and screenshots.

## Verification

- Release: https://github.com/zzedbot/wox-plugin-need/releases/tag/v0.2.1
- Four automated tests pass, including a Node.js host action-cache regression test.
- ESLint, Prettier, and the production build pass.
- The latest `.wox` download returns HTTP 200.