### PR TITLE
Update Linkding plugin to 1.1.0

### DIFF
--- a/store-plugin.json
+++ b/store-plugin.json
@@ -1204,7 +1204,7 @@
     "Id": "9d7b4e96-a81d-44a3-a75a-bc828cf5668e",
     "Name": "i18n:plugin_name",
     "Author": "Myraxion",
-    "Version": "1.0.0",
+    "Version": "1.1.0",
     "MinWoxVersion": "2.4.2",
     "Runtime": "python",
     "Description": "i18n:plugin_description",
@@ -1220,7 +1220,7 @@
       "Linux"
     ],
     "DateCreated": "2026-09-05 22:20:00",
-    "DateUpdated": "2026-09-05 22:20:00",
+    "DateUpdated": "2026-09-07 17:12:53",
     "I18n": {
       "en_US": {
         "plugin_name": "Linkding",

--- a/store-plugin.json
+++ b/store-plugin.json
@@ -1210,7 +1210,7 @@
     "Description": "i18n:plugin_description",
     "IconUrl": "https://raw.githubusercontent.com/Myraxion/Wox.Plugin.Linkding/main/images/app.svg",
     "Website": "https://github.com/Myraxion/Wox.Plugin.Linkding",
-    "DownloadUrl": "https://raw.githubusercontent.com/Myraxion/Wox.Plugin.Linkding/main/Wox.Plugin.Linkding.py",
+    "DownloadUrl": "https://github.com/Myraxion/Wox.Plugin.Linkding/releases/latest/download/Wox.Plugin.Linkding.py",
     "ScreenshotUrls": [
       "https://raw.githubusercontent.com/Myraxion/Wox.Plugin.Linkding/main/images/screenshot.png"
     ],


### PR DESCRIPTION
### Summary
Update **Linkding** plugin to version `1.1.0`.

- **Repository**: https://github.com/Myraxion/Wox.Plugin.Linkding
- **Release**: https://github.com/Myraxion/Wox.Plugin.Linkding/releases/tag/v1.1.0
- **Download URL**: https://github.com/Myraxion/Wox.Plugin.Linkding/releases/latest/download/Wox.Plugin.Linkding.py

### What's Changed
- **Release Asset Download URL**: Switched `DownloadUrl` to GitHub latest release asset URL to follow store best practices and enable Wox CI auto-update manifests.
- **Smart URL Normalization**: Automatically recognizes unprefixed URLs (e.g. copied from browser address bar) and prepends `https://` (or `http://` for localhost/127.0.0.1) without false-positive triggers on plain search keywords.
- **Selection Query Support**: Declares `querySelection` feature; supports launching via text selection hotkey with instant URL check/save card and split list preview panel (ADR-0003) for plain text bookmark aggregation.