### PR TITLE
Add Notion plugin to store

### DIFF
--- a/store-plugin.json
+++ b/store-plugin.json
@@ -1263,5 +1263,28 @@
         "plugin_description": "管理 GitHub 的 issues 和通知"
       }
     }
+  },
+  {
+    "Id": "73c73b8b-ef35-4d50-a2ca-e53484cd9561",
+    "Name": "Notion",
+    "Author": "lmgarret",
+    "Version": "1.0.1",
+    "MinWoxVersion": "2.0.4",
+    "Runtime": "nodejs",
+    "Description": "Search Notion pages and databases, jump to recent pages, and quick-capture notes from the launcher",
+    "IconUrl": "https://raw.githubusercontent.com/lmgarret/wox-notion-plugin/main/images/app.svg",
+    "Website": "https://github.com/lmgarret/wox-notion-plugin",
+    "DownloadUrl": "https://github.com/lmgarret/wox-notion-plugin/releases/latest/download/wox-notion-plugin.wox",
+    "ScreenshotUrls": [
+      "https://raw.githubusercontent.com/lmgarret/wox-notion-plugin/main/docs/screenshots/search.png",
+      "https://raw.githubusercontent.com/lmgarret/wox-notion-plugin/main/docs/screenshots/quick-capture.png"
+    ],
+    "SupportedOS": [
+      "Windows",
+      "Darwin",
+      "Linux"
+    ],
+    "DateCreated": "2026-09-08 12:57:47",
+    "DateUpdated": "2026-09-08 12:57:47"
   }
 ]


### PR DESCRIPTION
### Summary

Add [Notion](https://github.com/lmgarret/wox-notion-plugin) to the official Wox plugin store.

- **Plugin Name**: Notion
- **Plugin ID**: `73c73b8b-ef35-4d50-a2ca-e53484cd9561`
- **Runtime**: Node.js
- **Repository**: https://github.com/lmgarret/wox-notion-plugin
- **Release**: https://github.com/lmgarret/wox-notion-plugin/releases/tag/v1.0.1
- **Download URL**: https://github.com/lmgarret/wox-notion-plugin/releases/latest/download/wox-notion-plugin.wox
- **License**: GPL-3.0
- **Description**: Search Notion pages and databases, jump to recent pages, and quick-capture notes from the launcher.

### What it does

| Query | Result |
| --- | --- |
| `nt` | Most recently edited pages |
| `nt <term>` | Search pages and databases shared with your integration |
| `nt add <text>` | Create a page in a configured capture database |

Page results offer three actions: open in the Notion desktop app (with browser fallback), open in the browser, and copy the page link. Authentication is a user-supplied Notion internal integration token, entered in the plugin settings; a `QueryRequirements` entry prompts for it before any query runs.

### Notes

- `DownloadUrl` uses an unversioned filename so `releases/latest/download/` stays valid across releases and the store update bot can track new versions.
- The `.wox` is built and attached by CI from the tagged commit, and carries a [build provenance attestation](https://docs.github.com/actions/security-guides/using-artifact-attestations) (`gh attestation verify wox-notion-plugin.wox --repo lmgarret/wox-notion-plugin`).
- Tested on macOS; `SupportedOS` lists all three since there is no platform-specific code.